### PR TITLE
Add existence check and rename save to create

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/controller/AsignacionDocenteController.java
+++ b/src/main/java/com/imb2025/calificaciones/controller/AsignacionDocenteController.java
@@ -36,7 +36,7 @@ public class AsignacionDocenteController {
 
     @PostMapping
     public ResponseEntity<AsignacionDocente> create(@RequestBody AsignacionDocente asignacionDocente) {
-        AsignacionDocente createdAsignacionDocente = service.save(asignacionDocente);
+        AsignacionDocente createdAsignacionDocente = service.create(asignacionDocente);
         return ResponseEntity.ok(createdAsignacionDocente);
     }
 

--- a/src/main/java/com/imb2025/calificaciones/service/IAsignacionDocenteService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IAsignacionDocenteService.java
@@ -10,7 +10,9 @@ public interface IAsignacionDocenteService {
 
     List<AsignacionDocente> findAll();
 
-    AsignacionDocente save(AsignacionDocente asignacionDocente);
+    boolean existsById(Long id);
+
+    AsignacionDocente create(AsignacionDocente asignacionDocente);
 
     AsignacionDocente update(Long id, AsignacionDocente asignacionDocente) throws Exception;
 

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/AsignacionDocenteServiceImp.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/AsignacionDocenteServiceImp.java
@@ -23,26 +23,24 @@ public class AsignacionDocenteServiceImp implements IAsignacionDocenteService {
         return repository.findById(id).orElse(null);
     }
 
-    public AsignacionDocente existsById(Long id) {
-        return repository.existsById(id) ? findById(id) : null;
+    public boolean existsById(Long id) {
+        return repository.existsById(id);
     }
 
-    public AsignacionDocente save(AsignacionDocente asignacionDocente) {
+    public AsignacionDocente create(AsignacionDocente asignacionDocente) {
         return repository.save(asignacionDocente);
     }
 
-    public AsignacionDocente update(Long id, AsignacionDocente asignacionDocente) {
-        repository.findById(id).orElseThrow(
-                () -> new RuntimeException(
-                        "Can't update AsignacionDocente with id: " + id + " because it does not exist"));
+    public AsignacionDocente update(Long id, AsignacionDocente asignacionDocente) throws Exception {
+        repository.findById(id).orElseThrow(() ->
+                new Exception("Can't update AsignacionDocente with id: " + id + " because it does not exist"));
         asignacionDocente.setId(id);
         return repository.save(asignacionDocente);
     }
 
-    public void deleteById(Long id) {
+    public void deleteById(Long id) throws Exception {
         if (!repository.existsById(id)) {
-            throw new RuntimeException(
-                    "Can't delete AsignacionDocente with id: " + id + " because it does not exist");
+            throw new Exception("Can't delete AsignacionDocente with id: " + id + " because it does not exist");
         }
         repository.deleteById(id);
     }


### PR DESCRIPTION
## Summary
- add `existsById` to `IAsignacionDocenteService`
- rename `save` to `create` across controller and service
- ensure update and delete methods throw exceptions when entity is missing

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6892104de098832f8a5e833a235dd339