### PR TITLE
Refine AsignacionDocente service existence checks

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/service/jpa/AsignacionDocenteServiceImp.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/AsignacionDocenteServiceImp.java
@@ -32,15 +32,18 @@ public class AsignacionDocenteServiceImp implements IAsignacionDocenteService {
     }
 
     public AsignacionDocente update(Long id, AsignacionDocente asignacionDocente) throws Exception {
-        repository.findById(id).orElseThrow(() ->
-                new Exception("Can't update AsignacionDocente with id: " + id + " because it does not exist"));
+        if (!existsById(id)) {
+            throw new Exception(
+                    "Can't update AsignacionDocente with id: " + id + " because it does not exist");
+        }
         asignacionDocente.setId(id);
         return repository.save(asignacionDocente);
     }
 
     public void deleteById(Long id) throws Exception {
-        if (!repository.existsById(id)) {
-            throw new Exception("Can't delete AsignacionDocente with id: " + id + " because it does not exist");
+        if (!existsById(id)) {
+            throw new Exception(
+                    "Can't delete AsignacionDocente with id: " + id + " because it does not exist");
         }
         repository.deleteById(id);
     }


### PR DESCRIPTION
## Summary
- Ensure `existsById` returns a simple boolean check.
- Use `existsById` for update and delete operations to raise clear exceptions when records are missing.
- Controller uses the renamed `create` method for new assignments.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689212ef037c832fb93b2fbe73bc3394