### PR TITLE
Return 404 for missing AsignacionDocente

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/controller/AsignacionDocenteController.java
+++ b/src/main/java/com/imb2025/calificaciones/controller/AsignacionDocenteController.java
@@ -30,7 +30,7 @@ public class AsignacionDocenteController {
     public ResponseEntity<AsignacionDocente> getById(@PathVariable Long id) throws Exception {
         AsignacionDocente asignacionDocente = service.findById(id);
         if (asignacionDocente == null) {
-            return ResponseEntity.noContent().build();
+            return ResponseEntity.notFound().build();
         }
         return ResponseEntity.ok(asignacionDocente);
     }


### PR DESCRIPTION
## Summary
- Use HTTP 404 when an AsignacionDocente is not found

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689219fe71e0832f8a37066725a48985