### PR TITLE
Add existsById method to observacion alumno service

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/service/IObservacionAlumnoService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IObservacionAlumnoService.java
@@ -11,9 +11,10 @@ public interface IObservacionAlumnoService {
 	
 	Optional<ObservacionAlumno> findById(Long id);
 	List<ObservacionAlumno> findAll();
-	ObservacionAlumno create(ObservacionAlumno observacionAlumno);
-	ObservacionAlumno update(Long id, ObservacionAlumno observacionAlumno) throws Exception;
-	void deleteById(Long id);
+        ObservacionAlumno create(ObservacionAlumno observacionAlumno);
+        ObservacionAlumno update(Long id, ObservacionAlumno observacionAlumno) throws Exception;
+        void deleteById(Long id);
+        boolean existsById(Long id);
     ObservacionAlumno fromDTO(ObservacionAlumnoRequestDTO dto);
 	
 	

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/ObservacionAlumnoServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/ObservacionAlumnoServiceImpl.java
@@ -71,23 +71,28 @@ public class ObservacionAlumnoServiceImpl implements IObservacionAlumnoService{
 	
 
 	@Override
-	public void deleteById(Long id) throws Exception{
-		try {
-			Optional<ObservacionAlumno> obs = observacionAlumnoRepository.findById(id);
-			if (obs.isPresent()) {
-				observacionAlumnoRepository.deleteById(id);
-			} else {
-				throw new Exception("la observación de alumno no existe");
-			}
-		} catch (Exception e) {
-			throw new RuntimeException("error al eliminar la observación del alumno: " + e.getMessage()); 
-		}
-		
-	}
+        public void deleteById(Long id) throws Exception{
+                try {
+                        Optional<ObservacionAlumno> obs = observacionAlumnoRepository.findById(id);
+                        if (obs.isPresent()) {
+                                observacionAlumnoRepository.deleteById(id);
+                        } else {
+                                throw new Exception("la observación de alumno no existe");
+                        }
+                } catch (Exception e) {
+                        throw new RuntimeException("error al eliminar la observación del alumno: " + e.getMessage());
+                }
 
-	public ObservacionAlumno fromDTO(ObservacionAlumnoRequestDTO dto) {
-	    Docente docente = docenteRepository.findById(dto.getDocenteId())
-	            .orElseThrow(() -> new RuntimeException("docente no encontrado"));
+        }
+
+        @Override
+        public boolean existsById(Long id) {
+                return observacionAlumnoRepository.existsById(id);
+        }
+
+        public ObservacionAlumno fromDTO(ObservacionAlumnoRequestDTO dto) {
+            Docente docente = docenteRepository.findById(dto.getDocenteId())
+                    .orElseThrow(() -> new RuntimeException("docente no encontrado"));
 
 	    Alumno alumno = alumnoRepository.findById(dto.getAlumnoId())
 	            .orElseThrow(() -> new RuntimeException("alumno no encontrado"));


### PR DESCRIPTION
## Summary
- expose existsById in IObservacionAlumnoService
- implement repository-backed existsById lookup in ObservacionAlumnoServiceImpl

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6892434e0c2c832fb3b6f70504e52c1f