### PR TITLE
Handle checked exceptions in ObservacionAlumno service

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/service/IObservacionAlumnoService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IObservacionAlumnoService.java
@@ -13,7 +13,7 @@ public interface IObservacionAlumnoService {
 	List<ObservacionAlumno> findAll();
         ObservacionAlumno create(ObservacionAlumno observacionAlumno);
         ObservacionAlumno update(Long id, ObservacionAlumno observacionAlumno) throws Exception;
-        void deleteById(Long id);
+        void deleteById(Long id) throws Exception;
         boolean existsById(Long id);
     ObservacionAlumno fromDTO(ObservacionAlumnoRequestDTO dto);
 	

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/ObservacionAlumnoServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/ObservacionAlumnoServiceImpl.java
@@ -51,36 +51,26 @@ public class ObservacionAlumnoServiceImpl implements IObservacionAlumnoService{
 	
 
 	@Override
-	public ObservacionAlumno update(Long id, ObservacionAlumno observacionAlumno) throws Exception {
-		
-		try {
-			
-			Optional<ObservacionAlumno> obs = observacionAlumnoRepository.findById(id); 
-			
-			if(obs.isPresent()) {	
-				  observacionAlumno.setId(id);
-				  return observacionAlumnoRepository.save(observacionAlumno);
-			  } else {
-				  throw new Exception("la observación de alumno no existe");
-			  }  
-			
-		} catch (Exception e) {
-			throw new RuntimeException("error al actualizar la observación del alumno: " + e.getMessage());	 
-		}	  
-	}
+        public ObservacionAlumno update(Long id, ObservacionAlumno observacionAlumno) throws Exception {
+
+                Optional<ObservacionAlumno> obs = observacionAlumnoRepository.findById(id);
+
+                if (obs.isPresent()) {
+                        observacionAlumno.setId(id);
+                        return observacionAlumnoRepository.save(observacionAlumno);
+                } else {
+                        throw new Exception("la observación de alumno no existe");
+                }
+        }
 	
 
 	@Override
-        public void deleteById(Long id) throws Exception{
-                try {
-                        Optional<ObservacionAlumno> obs = observacionAlumnoRepository.findById(id);
-                        if (obs.isPresent()) {
-                                observacionAlumnoRepository.deleteById(id);
-                        } else {
-                                throw new Exception("la observación de alumno no existe");
-                        }
-                } catch (Exception e) {
-                        throw new RuntimeException("error al eliminar la observación del alumno: " + e.getMessage());
+        public void deleteById(Long id) throws Exception {
+                Optional<ObservacionAlumno> obs = observacionAlumnoRepository.findById(id);
+                if (obs.isPresent()) {
+                        observacionAlumnoRepository.deleteById(id);
+                } else {
+                        throw new Exception("la observación de alumno no existe");
                 }
 
         }


### PR DESCRIPTION
## Summary
- allow service methods to throw checked exceptions when an observation is missing
- align ObservacionAlumnoServiceImpl with interface signatures

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68924f0a8a68832fbb4029f769605485