### PR TITLE
feat: centralize ObservacionAlumno error handling

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/controller/ObservacionAlumnoController.java
+++ b/src/main/java/com/imb2025/calificaciones/controller/ObservacionAlumnoController.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -77,123 +78,49 @@ public class ObservacionAlumnoController {
 		}
 	}
 	
-	@PostMapping
-	public ResponseEntity<?> create(@RequestBody ObservacionAlumnoRequestDTO dto, HttpServletRequest request) {
-		try {	
-			
-			ObservacionAlumno observacionAlumno = observacionAlumnoService.create(observacionAlumnoService.fromDTO(dto));
-			
-			SuccessResponseDto<ObservacionAlumno> response = new SuccessResponseDto<>();
-			response.setTimestamp(LocalDateTime.now());
-			response.setStatus(HttpStatus.CREATED.value());
-			response.setMessage("observación creada correctamente");
-			response.setData(observacionAlumno);
-			
-			return ResponseEntity.status(HttpStatus.CREATED).body(response);
-			
-		} catch (Exception e) {
-			
-			ErrorResponseDto errorResponse = new ErrorResponseDto();
-			errorResponse.setTimestamp(LocalDateTime.now());
-			errorResponse.setStatus(HttpStatus.BAD_REQUEST.value());
-			errorResponse.setError("Bad Request");
-			
-			String errorMessage = e.getMessage();
-			String field = "general";
-			String errorCode = "CREATION_ERROR";
-			
-			if (errorMessage.contains("alumno no encontrado")) {
-				field = "alumnoId";
-				errorCode = "ALUMNO_NOT_FOUND";
-			} else if (errorMessage.contains("docente no encontrado")) {
-				field = "docenteId";
-				errorCode = "DOCENTE_NOT_FOUND";
-			}
-			
-			errorResponse.setMessages(Arrays.asList(
-				new ErrorMessage(field, errorMessage)
-			));
-			errorResponse.setErrorCode(errorCode);
-			errorResponse.setPath(request.getRequestURI());
-			
-			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
-			 
-		}	
-	}
-	
-	@PutMapping("/{id}")
-	public ResponseEntity<?> update(@RequestBody ObservacionAlumnoRequestDTO dto, @PathVariable Long id, HttpServletRequest request) {
-	try {	
-			
-			ObservacionAlumno observacionAlumno = observacionAlumnoService.update(id, observacionAlumnoService.fromDTO(dto));
-			
-			SuccessResponseDto<ObservacionAlumno> response = new SuccessResponseDto<>();
-			response.setTimestamp(LocalDateTime.now());
-			response.setStatus(HttpStatus.OK.value());
-			response.setMessage("observación actualizada correctamente");
-			response.setData(observacionAlumno);
-			
-			return ResponseEntity.ok(response);
-			
-		} catch (Exception e) {
-			
-			ErrorResponseDto errorResponse = new ErrorResponseDto();
-			errorResponse.setTimestamp(LocalDateTime.now());
-			errorResponse.setStatus(HttpStatus.NOT_FOUND.value());
-			errorResponse.setError("Not found");
-			
-			String errorMessage = e.getMessage();
-			String field = "id";
-			String errorCode = "UPDATE_ERROR";
-			
-			if (errorMessage.contains("la observación de alumno no existe")) {
-				errorCode = "OBSERVACION_NOT_FOUND";
-			} else if (errorMessage.contains("docente no encontrado")) {
-				field = "docenteId";
-				errorCode = "DOCENTE_NOT_FOUND";
-			} else if (errorMessage.contains("alumno no encontrado")) {
-				field = "alumnoId";
-				errorCode = "ALUMNO_NOT_FOUND";
-			}
-			
-			errorResponse.setMessages(Arrays.asList(
-				new ErrorMessage(field, errorMessage)
-			));
-			errorResponse.setErrorCode(errorCode);
-			errorResponse.setPath(request.getRequestURI());
-			
-			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
-			 
-		}	
-	}
-	
-	@DeleteMapping("/{id}")
-	public ResponseEntity<?> delete(@PathVariable Long id, HttpServletRequest request) {
-		try {
-			observacionAlumnoService.deleteById(id);
-			
-			SuccessResponseDto<String> response = new SuccessResponseDto<>();
-			response.setTimestamp(LocalDateTime.now());
-			response.setStatus(HttpStatus.OK.value());
-			response.setMessage("Observación eliminada exitosamente");
-			response.setData("Observación con ID " + id + " eliminada correctamente");
-			
-			return ResponseEntity.ok(response);
-			
-		} catch (Exception e) {
-			ErrorResponseDto errorResponse = new ErrorResponseDto();
-			errorResponse.setTimestamp(LocalDateTime.now());
-			errorResponse.setStatus(HttpStatus.NOT_FOUND.value());
-			errorResponse.setError("Not Found");
-			errorResponse.setMessages(Arrays.asList(
-				new ErrorMessage("id", e.getMessage())
-			));
-			errorResponse.setErrorCode("DELETE_ERROR");
-			errorResponse.setPath(request.getRequestURI());
-			
-			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
-		}
-	}
+        @PostMapping
+        public ResponseEntity<?> create(@RequestBody ObservacionAlumnoRequestDTO dto) {
+                ObservacionAlumno observacionAlumno = observacionAlumnoService.create(observacionAlumnoService.fromDTO(dto));
+
+                SuccessResponseDto<ObservacionAlumno> response = new SuccessResponseDto<>();
+                response.setTimestamp(LocalDateTime.now());
+                response.setStatus(HttpStatus.CREATED.value());
+                response.setMessage("observación creada correctamente");
+                response.setData(observacionAlumno);
+
+                return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        }
+
+        @PutMapping("/{id}")
+        public ResponseEntity<?> update(@RequestBody ObservacionAlumnoRequestDTO dto, @PathVariable Long id) {
+                ObservacionAlumno observacionAlumno = observacionAlumnoService.update(id, observacionAlumnoService.fromDTO(dto));
+
+                SuccessResponseDto<ObservacionAlumno> response = new SuccessResponseDto<>();
+                response.setTimestamp(LocalDateTime.now());
+                response.setStatus(HttpStatus.OK.value());
+                response.setMessage("observación actualizada correctamente");
+                response.setData(observacionAlumno);
+
+                return ResponseEntity.ok(response);
+        }
+
+        @DeleteMapping("/{id}")
+        public ResponseEntity<?> delete(@PathVariable Long id) {
+                observacionAlumnoService.deleteById(id);
+
+                SuccessResponseDto<String> response = new SuccessResponseDto<>();
+                response.setTimestamp(LocalDateTime.now());
+                response.setStatus(HttpStatus.OK.value());
+                response.setMessage("Observación eliminada exitosamente");
+                response.setData("Observación con ID " + id + " eliminada correctamente");
+
+                return ResponseEntity.ok(response);
+        }
+
+        @ExceptionHandler(Exception.class)
+        public ResponseEntity<String> handleException(Exception ex) {
+                return ResponseEntity.badRequest().body(ex.getMessage());
+        }
 	
  
 


### PR DESCRIPTION
## Summary
- simplify create/update/delete endpoints and let exceptions propagate
- add controller-level ExceptionHandler to return message with 400 status

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: org.springframework.boot:spring-boot-starter-parent:3.4.5)*

------
https://chatgpt.com/codex/tasks/task_e_68925072d6fc832f82768c32d080d67c