### PR TITLE
Refactor Asistencia entity imports and constructors

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/entity/Asistencia.java
+++ b/src/main/java/com/imb2025/calificaciones/entity/Asistencia.java
@@ -1,6 +1,10 @@
 package com.imb2025.calificaciones.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 
 @Entity
 public class Asistencia {
@@ -17,7 +21,22 @@ public class Asistencia {
 
     private Boolean presente;
 
-    // Getters y Setters
+    public Asistencia() {
+    }
+
+    public Asistencia(Long id, Alumno alumno, RegistroClase registroClase, Boolean presente) {
+        this.id = id;
+        this.alumno = alumno;
+        this.registroClase = registroClase;
+        this.presente = presente;
+    }
+
+    public Asistencia(Alumno alumno, RegistroClase registroClase, Boolean presente) {
+        this.alumno = alumno;
+        this.registroClase = registroClase;
+        this.presente = presente;
+    }
+
     public Long getId() {
         return id;
     }


### PR DESCRIPTION
## Summary
- replace wildcard JPA import in `Asistencia` with explicit imports
- remove obsolete getters/setters comment
- add empty and full-field constructors for `Asistencia`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: spring-boot-starter-parent 3.4.5 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c7272f3c832faa2045ac25eefb20