### PR TITLE
Refactor Comision entity with Turno and Sede relations

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/entity/Comision.java
+++ b/src/main/java/com/imb2025/calificaciones/entity/Comision.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 
 @Entity
 public class Comision {
@@ -15,9 +16,27 @@ public class Comision {
 	
 	private String nombre;
 	
-	private Long turnoId;
-	
-	private Long sedeId;
+        @ManyToOne
+        private Turno turno;
+
+        @ManyToOne
+        private Sede sede;
+
+        public Comision() {
+        }
+
+        public Comision(Long id, String nombre, Turno turno, Sede sede) {
+                this.id = id;
+                this.nombre = nombre;
+                this.turno = turno;
+                this.sede = sede;
+        }
+
+        public Comision(String nombre, Turno turno, Sede sede) {
+                this.nombre = nombre;
+                this.turno = turno;
+                this.sede = sede;
+        }
 	
 
 	public Long getId() {
@@ -36,20 +55,20 @@ public class Comision {
 		this.nombre = nombre;
 	}
 
-	public Long getTurnoId() {
-		return turnoId;
-	}
+        public Turno getTurno() {
+                return turno;
+        }
 
-	public void setTurnoId(Long turnoId) {
-		this.turnoId = turnoId;
-	}
+        public void setTurno(Turno turno) {
+                this.turno = turno;
+        }
 
-	public Long getSedeId() {
-		return sedeId;
-	}
+        public Sede getSede() {
+                return sede;
+        }
 
-	public void setSedeId(Long sedeId) {
-		this.sedeId = sedeId;
-	}
+        public void setSede(Sede sede) {
+                this.sede = sede;
+        }
 	
 }


### PR DESCRIPTION
## Summary
- replace `turnoId` and `sedeId` with `@ManyToOne` associations
- add constructors for entity with and without `id`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c72ce2f0832f9034f07104ac3f2d