### PR TITLE
Refactor Cursada to reference AnioLectivo entity

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/entity/AnioLectivo.java
+++ b/src/main/java/com/imb2025/calificaciones/entity/AnioLectivo.java
@@ -1,0 +1,39 @@
+package com.imb2025.calificaciones.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class AnioLectivo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String descripcion;
+
+    public AnioLectivo() {
+    }
+
+    public AnioLectivo(Long id, String descripcion) {
+        this.id = id;
+        this.descripcion = descripcion;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getDescripcion() {
+        return descripcion;
+    }
+
+    public void setDescripcion(String descripcion) {
+        this.descripcion = descripcion;
+    }
+}

--- a/src/main/java/com/imb2025/calificaciones/entity/Cursada.java
+++ b/src/main/java/com/imb2025/calificaciones/entity/Cursada.java
@@ -4,8 +4,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-
-import jakarta.persistence.*;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 
 @Entity
 public class Cursada {
@@ -14,24 +14,33 @@ public class Cursada {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // Relación con Alumno: muchos cursadas pueden tener un mismo alumno
     @ManyToOne
     @JoinColumn(name = "alumno_id")
     private Alumno alumno;
 
-    // Relación con Materia: muchos cursadas pueden tener una misma materia
     @ManyToOne
     @JoinColumn(name = "materia_id")
     private Materia materia;
 
-    private String anioLectivo;
+    @ManyToOne
+    @JoinColumn(name = "anio_lectivo_id")
+    private AnioLectivo anioLectivo;
 
-    // Relación con CondicionFinal: muchos cursadas pueden tener una misma condición
     @ManyToOne
     @JoinColumn(name = "condicion_final_id")
     private CondicionFinal condicionFinal;
 
-  
+    public Cursada() {
+    }
+
+    public Cursada(Long id, Alumno alumno, Materia materia, AnioLectivo anioLectivo, CondicionFinal condicionFinal) {
+        this.id = id;
+        this.alumno = alumno;
+        this.materia = materia;
+        this.anioLectivo = anioLectivo;
+        this.condicionFinal = condicionFinal;
+    }
+
     public Alumno getAlumno() {
         return alumno;
     }
@@ -48,11 +57,11 @@ public class Cursada {
         this.materia = materia;
     }
 
-    public String getAnioLectivo() {
+    public AnioLectivo getAnioLectivo() {
         return anioLectivo;
     }
 
-    public void setAnioLectivo(String anioLectivo) {
+    public void setAnioLectivo(AnioLectivo anioLectivo) {
         this.anioLectivo = anioLectivo;
     }
 

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/CursadaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/CursadaServiceImpl.java
@@ -74,7 +74,6 @@ public class CursadaServiceImpl implements ICursadaService{
 
                 cursada.setAlumno(alumno);
                 cursada.setMateria(materia);
-                cursada.setAnioLectivo("anioLectivoId");
                 cursada.setCondicionFinal(condicionFinal);
                 repo.save(cursada);
 


### PR DESCRIPTION
## Summary
- Replace `anioLectivo` String with `@ManyToOne AnioLectivo` in `Cursada` and add constructors
- Introduce `AnioLectivo` entity
- Remove outdated `setAnioLectivo` call from service implementation

## Testing
- `./mvnw -q test` *(fails: Failed to fetch maven distribution)*
- `mvn -q test` *(fails: Network is unreachable for parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c7308304832f9b1838a96715f879