### PR TITLE
Replace wildcard JPA import and add constructor for EstadoEvaluacion

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/entity/EstadoEvaluacion.java
+++ b/src/main/java/com/imb2025/calificaciones/entity/EstadoEvaluacion.java
@@ -1,6 +1,9 @@
 package com.imb2025.calificaciones.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 
 
 @Entity
@@ -15,6 +18,11 @@ public class EstadoEvaluacion {
     private String descripcion;
 
     public EstadoEvaluacion() {
+    }
+
+    public EstadoEvaluacion(String nombre, String descripcion) {
+        this.nombre = nombre;
+        this.descripcion = descripcion;
     }
 
     public EstadoEvaluacion(Long id, String nombre, String descripcion) {


### PR DESCRIPTION
## Summary
- replace wildcard JPA import with specific entity annotations
- add constructor without ID for EstadoEvaluacion entity

## Testing
- `mvn -q test` *(fails: org.springframework.boot:spring-boot-starter-parent:pom:3.4.5: Could not transfer artifact; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c73985a0832f849eea950234389d