### PR TITLE
Rename Evaluacion date field and add constructors

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/entity/Evaluacion.java
+++ b/src/main/java/com/imb2025/calificaciones/entity/Evaluacion.java
@@ -15,7 +15,7 @@ public class Evaluacion {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 	
-	private Date fechaEvaluacion;
+        private Date fecha;
 
 	@ManyToOne
 	private TipoEvaluacion tipoEvaluacion;
@@ -27,9 +27,24 @@ public class Evaluacion {
 	private Comision comision;
 
 	
-	public Evaluacion() {
-		super();
-	}
+        public Evaluacion() {
+                super();
+        }
+
+        public Evaluacion(Long id, Date fecha, TipoEvaluacion tipoEvaluacion, Materia materia, Comision comision) {
+                this.id = id;
+                this.fecha = fecha;
+                this.tipoEvaluacion = tipoEvaluacion;
+                this.materia = materia;
+                this.comision = comision;
+        }
+
+        public Evaluacion(Date fecha, TipoEvaluacion tipoEvaluacion, Materia materia, Comision comision) {
+                this.fecha = fecha;
+                this.tipoEvaluacion = tipoEvaluacion;
+                this.materia = materia;
+                this.comision = comision;
+        }
 
 	public Long getId() {
 		return id;
@@ -39,13 +54,13 @@ public class Evaluacion {
 		this.id = id;
 	}
 
-	public Date getFechaEvaluacion() {
-		return fechaEvaluacion;
-	}
+        public Date getFecha() {
+                return fecha;
+        }
 
-	public void setFechaEvaluacion(Date fechaEvaluacion) {
-		this.fechaEvaluacion = fechaEvaluacion;
-	}
+        public void setFecha(Date fecha) {
+                this.fecha = fecha;
+        }
 
 	public TipoEvaluacion getTipoEvaluacion() {
 		return tipoEvaluacion;

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/EvaluacionServiceImp.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/EvaluacionServiceImp.java
@@ -63,10 +63,10 @@ public class EvaluacionServiceImp implements IEvaluacionService {
 					.orElseThrow(() -> new RuntimeException("Evaluación no encontrada"));
 
 			
-			evaluacion.setComision(newEvaluacion.getComision());
-			evaluacion.setMateria(newEvaluacion.getMateria());
-			evaluacion.setFechaEvaluacion(newEvaluacion.getFechaEvaluacion());
-			evaluacion.setTipoEvaluacion(newEvaluacion.getTipoEvaluacion());
+                        evaluacion.setComision(newEvaluacion.getComision());
+                        evaluacion.setMateria(newEvaluacion.getMateria());
+                        evaluacion.setFecha(newEvaluacion.getFecha());
+                        evaluacion.setTipoEvaluacion(newEvaluacion.getTipoEvaluacion());
 
 			return evaluacionRepository.save(evaluacion);
 
@@ -108,8 +108,8 @@ public class EvaluacionServiceImp implements IEvaluacionService {
 				}
 				evaluacion.setComision(comision);
 			}
-			evaluacion.setId(evaluacionRequestDTO.getId());
-			evaluacion.setFechaEvaluacion(evaluacionRequestDTO.getFechaEvaluacion());
+                        evaluacion.setId(evaluacionRequestDTO.getId());
+                        evaluacion.setFecha(evaluacionRequestDTO.getFechaEvaluacion());
 			return evaluacion;
 		} catch (Exception e) {
 			throw new RuntimeException("Error: " + e.getMessage());


### PR DESCRIPTION
## Summary
- rename `fechaEvaluacion` field to `fecha`
- add overloaded constructors for `Evaluacion`
- adjust service layer to use new `fecha` field

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c73cef58832f867b71d2f95c6a07