### PR TITLE
Refactor ObservacionAlumno entity and add constructors

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/entity/ObservacionAlumno.java
+++ b/src/main/java/com/imb2025/calificaciones/entity/ObservacionAlumno.java
@@ -6,12 +6,9 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 
 @Entity
-@Table(name = "observacion_alumno")
 public class ObservacionAlumno {
 	
 	@Id
@@ -21,12 +18,28 @@ public class ObservacionAlumno {
     private Date fecha;
     
     @ManyToOne
-    @JoinColumn(name = "docente_id")
     private Docente docente;
-    
+
     @ManyToOne
-    @JoinColumn(name = "alumno_id")
     private Alumno alumno;
+
+    public ObservacionAlumno() {
+    }
+
+    public ObservacionAlumno(Long id, String texto, Date fecha, Docente docente, Alumno alumno) {
+        this.id = id;
+        this.texto = texto;
+        this.fecha = fecha;
+        this.docente = docente;
+        this.alumno = alumno;
+    }
+
+    public ObservacionAlumno(String texto, Date fecha, Docente docente, Alumno alumno) {
+        this.texto = texto;
+        this.fecha = fecha;
+        this.docente = docente;
+        this.alumno = alumno;
+    }
 	
 	public Long getId() {
 		return id;


### PR DESCRIPTION
## Summary
- Remove redundant JPA `@Table` and `@JoinColumn` annotations from `ObservacionAlumno`
- Add empty, complete, and idless constructors for `ObservacionAlumno`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c74fec20832fae43b47f9d423fc3