### PR TITLE
Refactor PlanEstudio entity to use Carrera relation

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/entity/PlanEstudio.java
+++ b/src/main/java/com/imb2025/calificaciones/entity/PlanEstudio.java
@@ -1,50 +1,65 @@
 package com.imb2025.calificaciones.entity;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 
 @Entity
-@Table(name = "plan_estudio")
-
-
 public class PlanEstudio {
-	
-	
 
-	    @Id
-	    @GeneratedValue(strategy = GenerationType.IDENTITY)
-	    private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	    @Column(name = "carrera_id", nullable = false)
-	    private Long carreraId;
+    @ManyToOne
+    @JoinColumn(name = "carrera_id")
+    private Carrera carrera;
 
-	    @Column(nullable = false)
-	    private String nombre;
+    private String nombre;
 
-	    @Column(name = "anio_vigencia", nullable = false)
-	    private int anioVigencia;
+    private int anioVigencia;
 
-	    
-	    public Long getId() { return id; }
+    public PlanEstudio() {
+    }
 
-	    public void setId(Long id) { this.id = id; }
+    public PlanEstudio(Carrera carrera, String nombre, int anioVigencia) {
+        this.carrera = carrera;
+        this.nombre = nombre;
+        this.anioVigencia = anioVigencia;
+    }
 
-	    public Long getCarreraId() { return carreraId; }
+    public Long getId() {
+        return id;
+    }
 
-	    public void setCarreraId(Long long1) { this.carreraId = long1; }
+    public void setId(Long id) {
+        this.id = id;
+    }
 
-	    public String getNombre() { return nombre; }
+    public Carrera getCarrera() {
+        return carrera;
+    }
 
-	    public void setNombre(String nombre) { this.nombre = nombre; }
+    public void setCarrera(Carrera carrera) {
+        this.carrera = carrera;
+    }
 
-	    public int getAnioVigencia() { return anioVigencia; }
+    public String getNombre() {
+        return nombre;
+    }
 
-	    public void setAnioVigencia(int anioVigencia) { this.anioVigencia = anioVigencia; }
-	
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
 
+    public int getAnioVigencia() {
+        return anioVigencia;
+    }
 
+    public void setAnioVigencia(int anioVigencia) {
+        this.anioVigencia = anioVigencia;
+    }
 }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/PlanEstudioServiceImp.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/PlanEstudioServiceImp.java
@@ -1,7 +1,6 @@
 package com.imb2025.calificaciones.service.jpa;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -54,9 +53,11 @@ public class PlanEstudioServiceImp implements IPlanEstudioService {
             }
 
             // Validar existencia de carrera
-            if (newPlanEstudio.getCarreraId() == null ||
-                carreraRepository.existsById(newPlanEstudio.getCarreraId())) {
-                throw new EntidadNoEncontradaException("Carrera con ID " + newPlanEstudio.getCarreraId() + " no existe");
+            if (newPlanEstudio.getCarrera() == null ||
+                newPlanEstudio.getCarrera().getId() == null ||
+                !carreraRepository.existsById(newPlanEstudio.getCarrera().getId())) {
+                Long carreraId = newPlanEstudio.getCarrera() != null ? newPlanEstudio.getCarrera().getId() : null;
+                throw new EntidadNoEncontradaException("Carrera con ID " + carreraId + " no existe");
             }
             
             
@@ -69,7 +70,7 @@ public class PlanEstudioServiceImp implements IPlanEstudioService {
             */
 
             // Actualizar campos
-            existente.setCarreraId(newPlanEstudio.getCarreraId());
+            existente.setCarrera(newPlanEstudio.getCarrera());
             existente.setNombre(newPlanEstudio.getNombre());
             existente.setAnioVigencia(newPlanEstudio.getAnioVigencia());
 
@@ -96,12 +97,9 @@ public class PlanEstudioServiceImp implements IPlanEstudioService {
         PlanEstudio plan = new PlanEstudio();
 
         // Validar carrera
-        /*
         Carrera carrera = carreraRepository.findById(dto.getCarreraId())
             .orElseThrow(() -> new EntidadNoEncontradaException("Carrera con ID " + dto.getCarreraId() + " no encontrada"));
-        plan.setCarreraId(carrera);
-        */
-        plan.setCarreraId(dto.getCarreraId());
+        plan.setCarrera(carrera);
        
 
         // Validar nombre


### PR DESCRIPTION
## Summary
- Link `PlanEstudio` with `Carrera` via `@ManyToOne` instead of a raw ID, adding constructors and cleaning unnecessary annotations.
- Adjust service logic to work with `Carrera` entities and validate existence before saving.

## Testing
- `./mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c758643c832f91b88f2f87403875