### PR TITLE
Actualizar RegistroClase a relaciones ManyToOne

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/entity/RegistroClase.java
+++ b/src/main/java/com/imb2025/calificaciones/entity/RegistroClase.java
@@ -2,13 +2,12 @@ package com.imb2025.calificaciones.entity;
 
 import java.time.LocalDate;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 
 @Entity
 public class RegistroClase {
@@ -17,23 +16,41 @@ public class RegistroClase {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "fecha_clase", nullable = false)
     private LocalDate fecha;
 
-    @Column(name = "tema_materia", nullable = false)
     private String tema;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "docente_id", nullable = false)
     private Docente docente;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "comision_id", nullable = false)
     private Comision comision;
+    
+    public RegistroClase() {
+    }
 
-    // Getters y Setters
+    public RegistroClase(Long id, LocalDate fecha, String tema, Docente docente, Comision comision) {
+        this.id = id;
+        this.fecha = fecha;
+        this.tema = tema;
+        this.docente = docente;
+        this.comision = comision;
+    }
+
+    public RegistroClase(LocalDate fecha, String tema, Docente docente, Comision comision) {
+        this.fecha = fecha;
+        this.tema = tema;
+        this.docente = docente;
+        this.comision = comision;
+    }
     public Long getId() {
         return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
     }
 
     public LocalDate getFecha() {


### PR DESCRIPTION
## Summary
- Cambiar anotaciones @OneToOne por @ManyToOne en `RegistroClase`
- Eliminar anotaciones @Column y comentario
- Agregar constructor sin argumentos, con todos los campos y sin id, además de setter para id

## Testing
- `./mvnw -q test` *(failed: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c75e2bcc832fad1f4a8d872a5503