### PR TITLE
Add constructors to Turno entity

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/entity/Turno.java
+++ b/src/main/java/com/imb2025/calificaciones/entity/Turno.java
@@ -14,11 +14,27 @@ public class Turno {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 	
-	private String nombre;
-	
-	private LocalTime horaInicio;
-	
-	private LocalTime horaFin;
+        private String nombre;
+
+        private LocalTime horaInicio;
+
+        private LocalTime horaFin;
+
+        public Turno() {
+        }
+
+        public Turno(Long id, String nombre, LocalTime horaInicio, LocalTime horaFin) {
+                this.id = id;
+                this.nombre = nombre;
+                this.horaInicio = horaInicio;
+                this.horaFin = horaFin;
+        }
+
+        public Turno(String nombre, LocalTime horaInicio, LocalTime horaFin) {
+                this.nombre = nombre;
+                this.horaInicio = horaInicio;
+                this.horaFin = horaFin;
+        }
 	
 	public Long getId() {
 		return id;


### PR DESCRIPTION
## Summary
- add default, full-field, and partial constructors to Turno entity

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c770721c832fb3df730c5dd8545d