### PR TITLE
feat: add AnioLectivo entity

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/entity/AnioLectivo.java
+++ b/src/main/java/com/imb2025/calificaciones/entity/AnioLectivo.java
@@ -1,0 +1,54 @@
+package com.imb2025.calificaciones.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class AnioLectivo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private int anio;
+    private boolean activo;
+
+    public AnioLectivo() {
+    }
+
+    public AnioLectivo(Long id, int anio, boolean activo) {
+        this.id = id;
+        this.anio = anio;
+        this.activo = activo;
+    }
+
+    public AnioLectivo(int anio, boolean activo) {
+        this.anio = anio;
+        this.activo = activo;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public int getAnio() {
+        return anio;
+    }
+
+    public void setAnio(int anio) {
+        this.anio = anio;
+    }
+
+    public boolean isActivo() {
+        return activo;
+    }
+
+    public void setActivo(boolean activo) {
+        this.activo = activo;
+    }
+}


### PR DESCRIPTION
## Summary
- add AnioLectivo entity with id, year, active fields
- include full, partial, and empty constructors plus accessors

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c77623d0832f888a2ab6c3798654