### PR TITLE
Remove wildcard imports in entity classes

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/entity/NivelMateria.java
+++ b/src/main/java/com/imb2025/calificaciones/entity/NivelMateria.java
@@ -1,6 +1,9 @@
 package com.imb2025.calificaciones.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 
 @Entity
 public class NivelMateria {

--- a/src/main/java/com/imb2025/calificaciones/entity/Nota.java
+++ b/src/main/java/com/imb2025/calificaciones/entity/Nota.java
@@ -1,6 +1,10 @@
 package com.imb2025.calificaciones.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 
 @Entity
 public class Nota {


### PR DESCRIPTION
## Summary
- replace wildcard JPA imports in `NivelMateria` and `Nota` with explicit class imports

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d139cdc0832fb4eff3b14c926162