### PR TITLE
Implement missing service methods

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/service/jpa/AlumnoServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/AlumnoServiceImpl.java
@@ -18,11 +18,12 @@ public class AlumnoServiceImpl implements IAlumnoServices {
 
     @Override
     public Alumno update(AlumnoRequestDto datosActualizados, Long id) throws Exception {
-        if (alumnoRepository.existsById(id)) {
-            return fromDto(datosActualizados);
-        } else {
+        if (!alumnoRepository.existsById(id)) {
             throw new Exception("Estudiante no encontrado");
         }
+        Alumno alumno = fromDto(datosActualizados);
+        alumno.setId(id);
+        return alumnoRepository.save(alumno);
     }
 
     @Override
@@ -37,8 +38,8 @@ public class AlumnoServiceImpl implements IAlumnoServices {
 
     @Override
     public Alumno create(AlumnoRequestDto nuevoAlumno) {
-        return fromDto(nuevoAlumno);
-
+        Alumno alumno = fromDto(nuevoAlumno);
+        return alumnoRepository.save(alumno);
     }
 
     @Override
@@ -61,8 +62,12 @@ public class AlumnoServiceImpl implements IAlumnoServices {
         } catch (Exception e) {
             throw new IllegalArgumentException("Formato de fecha incorrecto. Se espera yyyy-MM-dd.");
         }
-        alumnoRepository.save(alumno);
         return alumno;
     }
+
+    @Override
+    public boolean existsById(Long id) {
+        return alumnoRepository.existsById(id);
     }
+}
 

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/EstadoEvaluacionServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/EstadoEvaluacionServiceImpl.java
@@ -1,52 +1,61 @@
 package com.imb2025.calificaciones.service.jpa;
 
-import com.imb2025.calificaciones.entity.EstadoEvaluacion;
-import com.imb2025.calificaciones.repository.EstadoEvaluacionRepository;
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import com.imb2025.calificaciones.dto.EstadoEvaluacionRequestDto;
+import com.imb2025.calificaciones.entity.EstadoEvaluacion;
+import com.imb2025.calificaciones.repository.EstadoEvaluacionRepository;
+import com.imb2025.calificaciones.service.IEstadoEvaluacionService;
 
 @Service
-public class EstadoEvaluacionServiceImpl  {
+public class EstadoEvaluacionServiceImpl implements IEstadoEvaluacionService {
 
     @Autowired
     private EstadoEvaluacionRepository repository;
 
     @Override
-    public List<EstadoEvaluacion> getAll() {
+    public List<EstadoEvaluacion> findAll() {
         return repository.findAll();
-    }
-
-    @Override
-    @Transactional
-    public EstadoEvaluacion save(EstadoEvaluacion estadoEvaluacion) {
-        EstadoEvaluacion estado = new EstadoEvaluacion();
-        estado.setNombre(estadoEvaluacion.getNombre());
-        estado.setDescripcion(estadoEvaluacion.getDescripcion());
-        return repository.save(estado);
-    }
-
-    @Override
-    @Transactional
-    public EstadoEvaluacion update(EstadoEvaluacion estadoEvaluacion, Long id) {
-        EstadoEvaluacion existente = repository.findById(id).orElse(null);
-        if (existente != null) {
-            existente.setNombre(estadoEvaluacion.getNombre());
-            existente.setDescripcion(estadoEvaluacion.getDescripcion());
-            return repository.save(existente);
-        }
-        return null;
-    }
-
-    @Override
-    public void delete(Long id) {
-        repository.deleteById(id);
     }
 
     @Override
     public EstadoEvaluacion findById(Long id) {
         return repository.findById(id).orElse(null);
+    }
+
+    @Override
+    @Transactional
+    public EstadoEvaluacion create(EstadoEvaluacionRequestDto dto) {
+        EstadoEvaluacion estado = fromDto(dto);
+        return repository.save(estado);
+    }
+
+    @Override
+    @Transactional
+    public EstadoEvaluacion update(Long id, EstadoEvaluacionRequestDto dto) {
+        EstadoEvaluacion existente = repository.findById(id).orElse(null);
+        if (existente == null) {
+            return null;
+        }
+        existente.setNombre(dto.getNombre());
+        existente.setDescripcion(dto.getDescripcion());
+        return repository.save(existente);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        repository.deleteById(id);
+    }
+
+    @Override
+    public EstadoEvaluacion fromDto(EstadoEvaluacionRequestDto dto) {
+        EstadoEvaluacion estado = new EstadoEvaluacion();
+        estado.setNombre(dto.getNombre());
+        estado.setDescripcion(dto.getDescripcion());
+        return estado;
     }
 }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/ObservacionAlumnoServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/ObservacionAlumnoServiceImpl.java
@@ -29,13 +29,11 @@ public class ObservacionAlumnoServiceImpl implements IObservacionAlumnoService{
 
     @Override
     public Optional<ObservacionAlumno> findById(Long id) {
-        // TODO Auto-generated method stub
         return observacionAlumnoRepository.findById(id);
     }
 
     @Override
     public List<ObservacionAlumno> findAll() {
-        // TODO Auto-generated method stub
         return observacionAlumnoRepository.findAll();
     }
 
@@ -50,7 +48,7 @@ public class ObservacionAlumnoServiceImpl implements IObservacionAlumnoService{
     }
 
     @Override
-    public ObservacionAlumno update(ObservacionAlumno observacionAlumno, Long id) throws Exception {
+    public ObservacionAlumno update(Long id, ObservacionAlumno observacionAlumno) throws Exception {
 
         try {
 


### PR DESCRIPTION
## Summary
- Align ObservacionAlumnoServiceImpl with its interface and swap update parameter order
- Complete AlumnoServiceImpl with proper DTO mapping, persistence logic, and `existsById`
- Implement EstadoEvaluacionServiceImpl based on IEstadoEvaluacionService, adding DTO conversion and CRUD logic

## Testing
- `mvn -q -e -DskipTests=true package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a11c4fc020832f930d0606d7a0c2a9