### PR TITLE
Align key service implementations with interfaces

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/service/jpa/AlumnoServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/AlumnoServiceImpl.java
@@ -3,25 +3,23 @@ package com.imb2025.calificaciones.service.jpa;
 import com.imb2025.calificaciones.dto.AlumnoRequestDto;
 import com.imb2025.calificaciones.entity.Alumno;
 import com.imb2025.calificaciones.repository.AlumnoRepository;
-import com.imb2025.calificaciones.service.IAlumnoServices;
+import com.imb2025.calificaciones.service.IAlumnoService;
+import java.text.SimpleDateFormat;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.text.SimpleDateFormat;
-import java.util.List;
-
 @Service
-public class AlumnoServiceImpl implements IAlumnoServices {
+public class AlumnoServiceImpl implements IAlumnoService {
 
     @Autowired
     private AlumnoRepository alumnoRepository;
 
     @Override
-    public Alumno update(AlumnoRequestDto datosActualizados, Long id) throws Exception {
+    public Alumno update(Alumno alumno, Long id) throws Exception {
         if (!alumnoRepository.existsById(id)) {
             throw new Exception("Estudiante no encontrado");
         }
-        Alumno alumno = fromDto(datosActualizados);
         alumno.setId(id);
         return alumnoRepository.save(alumno);
     }
@@ -37,8 +35,7 @@ public class AlumnoServiceImpl implements IAlumnoServices {
     }
 
     @Override
-    public Alumno create(AlumnoRequestDto nuevoAlumno) {
-        Alumno alumno = fromDto(nuevoAlumno);
+    public Alumno create(Alumno alumno) {
         return alumnoRepository.save(alumno);
     }
 
@@ -50,7 +47,8 @@ public class AlumnoServiceImpl implements IAlumnoServices {
             throw new RuntimeException("Estudiante no encontrado");
         }
     }
-     @Override
+
+    @Override
     public Alumno fromDto(AlumnoRequestDto alumnoDto) {
         Alumno alumno = new Alumno();
         alumno.setNombre(alumnoDto.getNombre());
@@ -63,11 +61,6 @@ public class AlumnoServiceImpl implements IAlumnoServices {
             throw new IllegalArgumentException("Formato de fecha incorrecto. Se espera yyyy-MM-dd.");
         }
         return alumno;
-    }
-
-    @Override
-    public boolean existsById(Long id) {
-        return alumnoRepository.existsById(id);
     }
 }
 

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/AsignacionDocenteServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/AsignacionDocenteServiceImpl.java
@@ -1,11 +1,18 @@
 package com.imb2025.calificaciones.service.jpa;
 
+import com.imb2025.calificaciones.dto.AsignacionDocenteRequestDto;
 import com.imb2025.calificaciones.entity.AsignacionDocente;
+import com.imb2025.calificaciones.entity.Comision;
+import com.imb2025.calificaciones.entity.Docente;
+import com.imb2025.calificaciones.entity.Materia;
+import com.imb2025.calificaciones.entity.PeriodoLectivo;
 import com.imb2025.calificaciones.repository.AsignacionDocenteRepository;
+import com.imb2025.calificaciones.repository.ComisionRepository;
+import com.imb2025.calificaciones.repository.DocenteRepository;
+import com.imb2025.calificaciones.repository.MateriaRepository;
+import com.imb2025.calificaciones.repository.PeriodoLectivoRepository;
 import com.imb2025.calificaciones.service.IAsignacionDocenteService;
-
 import java.util.List;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -15,18 +22,34 @@ public class AsignacionDocenteServiceImpl implements IAsignacionDocenteService {
     @Autowired
     private AsignacionDocenteRepository repository;
 
+    @Autowired
+    private DocenteRepository docenteRepository;
+
+    @Autowired
+    private MateriaRepository materiaRepository;
+
+    @Autowired
+    private ComisionRepository comisionRepository;
+
+    @Autowired
+    private PeriodoLectivoRepository periodoLectivoRepository;
+
+    @Override
     public List<AsignacionDocente> findAll() {
         return repository.findAll();
     }
 
+    @Override
     public AsignacionDocente findById(Long id) {
         return repository.findById(id).orElse(null);
     }
 
+    @Override
     public AsignacionDocente create(AsignacionDocente asignacionDocente) {
         return repository.save(asignacionDocente);
     }
 
+    @Override
     public AsignacionDocente update(AsignacionDocente asignacionDocente, Long id) throws Exception {
         if (!repository.existsById(id)) {
             throw new Exception(
@@ -36,11 +59,21 @@ public class AsignacionDocenteServiceImpl implements IAsignacionDocenteService {
         return repository.save(asignacionDocente);
     }
 
+    @Override
     public void deleteById(Long id) throws Exception {
         if (!repository.existsById(id)) {
             throw new Exception(
                     "Can't delete AsignacionDocente with id: " + id + " because it does not exist");
         }
         repository.deleteById(id);
+    }
+
+    @Override
+    public AsignacionDocente fromDto(AsignacionDocenteRequestDto dto) {
+        Docente docente = docenteRepository.findById(dto.getDocenteId()).orElse(null);
+        Materia materia = materiaRepository.findById(dto.getMateriaId()).orElse(null);
+        Comision comision = comisionRepository.findById(dto.getComisionId()).orElse(null);
+        PeriodoLectivo periodoLectivo = periodoLectivoRepository.findById(dto.getPeriodoLectivoId()).orElse(null);
+        return new AsignacionDocente(docente, materia, comision, periodoLectivo);
     }
 }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/CalendarioMateriaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/CalendarioMateriaServiceImpl.java
@@ -1,26 +1,20 @@
 package com.imb2025.calificaciones.service.jpa;
 
-import java.util.List;
-import java.util.Optional;
-
 import com.imb2025.calificaciones.dto.CalendarioMateriaRequestDto;
+import com.imb2025.calificaciones.entity.CalendarioMateria;
 import com.imb2025.calificaciones.entity.Comision;
 import com.imb2025.calificaciones.entity.Materia;
 import com.imb2025.calificaciones.repository.ComisionRepository;
+import com.imb2025.calificaciones.repository.ICalendarioMateriaRepository;
 import com.imb2025.calificaciones.repository.MateriaRepository;
-import jakarta.persistence.EntityNotFoundException;
-
+import com.imb2025.calificaciones.service.ICalendarioMateriaService;
+import jakarta.transaction.Transactional;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.imb2025.calificaciones.entity.CalendarioMateria;
-import com.imb2025.calificaciones.repository.ICalendarioMateriaRepository;
-import com.imb2025.calificaciones.service.ICalendarioMateriaService;
-
-import jakarta.transaction.Transactional;
-
 @Service
-public class CalendarioMateriaServiceImpl implements ICalendarioMateriaService{
+public class CalendarioMateriaServiceImpl implements ICalendarioMateriaService {
 
     @Autowired
     private ICalendarioMateriaRepository calMatRepo;
@@ -36,7 +30,7 @@ public class CalendarioMateriaServiceImpl implements ICalendarioMateriaService{
 
     @Override
     @Transactional
-    public CalendarioMateria findByID(Long id) {
+    public CalendarioMateria findById(Long id) {
         return calMatRepo.findById(id).orElseThrow();
     }
 
@@ -58,12 +52,10 @@ public class CalendarioMateriaServiceImpl implements ICalendarioMateriaService{
 
     @Override
     @Transactional
-    public void delete(Long id) {
-
-        if (calMatRepo.existsById(id)){
+    public void deleteById(Long id) {
+        if (calMatRepo.existsById(id)) {
             calMatRepo.deleteById(id);
         }
-
     }
 
     @Override

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/ComisionServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/ComisionServiceImpl.java
@@ -1,44 +1,62 @@
 package com.imb2025.calificaciones.service.jpa;
 
+import com.imb2025.calificaciones.dto.ComisionRequestDto;
+import com.imb2025.calificaciones.entity.Comision;
+import com.imb2025.calificaciones.entity.Sede;
+import com.imb2025.calificaciones.entity.Turno;
+import com.imb2025.calificaciones.repository.ComisionRepository;
+import com.imb2025.calificaciones.repository.SedeRepository;
+import com.imb2025.calificaciones.repository.TurnoRepository;
+import com.imb2025.calificaciones.service.IComisionService;
 import java.util.List;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.imb2025.calificaciones.entity.Comision;
-import com.imb2025.calificaciones.repository.ComisionRepository;
-import com.imb2025.calificaciones.service.IComisionService;
-
 @Service
-public class ComisionServiceImpl implements IComisionService{
+public class ComisionServiceImpl implements IComisionService {
 
     @Autowired
     private ComisionRepository repository;
 
+    @Autowired
+    private TurnoRepository turnoRepository;
+
+    @Autowired
+    private SedeRepository sedeRepository;
+
     @Override
     public List<Comision> findAll() {
-         return repository.findAll();
+        return repository.findAll();
     }
 
     @Override
     public Comision findById(Long id) {
-         return repository.findById(id).orElse(null);
+        return repository.findById(id).orElse(null);
     }
 
     @Override
-    public Comision save(Comision Comision) {
-         return repository.save(Comision);
+    public Comision create(Comision comision) {
+        return repository.save(comision);
     }
 
     @Override
-    public Comision update(Comision Comision, Long id) {
-        Comision.setId(id);
-        return repository.save(Comision);
+    public Comision update(Comision comision, Long id) {
+        comision.setId(id);
+        return repository.save(comision);
     }
 
     @Override
     public void deleteById(Long id) {
         repository.deleteById(id);
+    }
 
+    @Override
+    public Comision fromDto(ComisionRequestDto dto) {
+        if (dto == null) {
+            return null;
+        }
+        Turno turno = turnoRepository.findById(dto.getTurnoId()).orElse(null);
+        Sede sede = sedeRepository.findById(dto.getSedeId()).orElse(null);
+        return new Comision(dto.getNombre(), turno, sede);
     }
 }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/CondicionFinalServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/CondicionFinalServiceImpl.java
@@ -1,14 +1,12 @@
 package com.imb2025.calificaciones.service.jpa;
 
+import com.imb2025.calificaciones.dto.CondicionFinalRequestDto;
 import com.imb2025.calificaciones.entity.CondicionFinal;
 import com.imb2025.calificaciones.repository.CondicionFinalRepository;
 import com.imb2025.calificaciones.service.ICondicionFinalService;
-
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.Optional;
 
 @Service
 public class CondicionFinalServiceImpl implements ICondicionFinalService {
@@ -16,20 +14,42 @@ public class CondicionFinalServiceImpl implements ICondicionFinalService {
     @Autowired
     private CondicionFinalRepository repository;
 
-    public List<CondicionFinal> getAll() {
+    @Override
+    public List<CondicionFinal> findAll() {
         return repository.findAll();
     }
 
-    public CondicionFinal save(CondicionFinal cf) {
-        return repository.save(cf);
+    @Override
+    public CondicionFinal create(CondicionFinal condicionFinal) {
+        return repository.save(condicionFinal);
     }
 
-    public CondicionFinal getById(Long id) {
-        Optional<CondicionFinal> result = repository.findById(id);
-        return result.orElse(null);
+    @Override
+    public CondicionFinal update(CondicionFinal condicionFinal, Long id) throws Exception {
+        if (!repository.existsById(id)) {
+            throw new Exception("CondicionFinal not found");
+        }
+        condicionFinal.setId(id);
+        return repository.save(condicionFinal);
     }
 
-    public void delete(Long id) {
+    @Override
+    public CondicionFinal findById(Long id) {
+        return repository.findById(id).orElse(null);
+    }
+
+    @Override
+    public void deleteById(Long id) {
         repository.deleteById(id);
+    }
+
+    @Override
+    public CondicionFinal fromDto(CondicionFinalRequestDto dto) {
+        if (dto == null) {
+            return null;
+        }
+        CondicionFinal condicionFinal = new CondicionFinal();
+        condicionFinal.setNombre(dto.getNombre());
+        return condicionFinal;
     }
 }


### PR DESCRIPTION
## Summary
- Refactor AlumnoServiceImpl to use entity-based create/update and clean imports
- Implement DTO mapping and explicit access modifiers in AsignacionDocenteServiceImpl
- Normalize CalendarioMateria, CondicionFinal and Comision services to match interfaces and remove unused imports

## Testing
- `mvn -q -DskipTests compile` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1280f3e7c832f9eaf4fd879fe4827