### PR TITLE
Add DTO to entity mapping with validations

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/service/IAlumnoService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IAlumnoService.java
@@ -16,5 +16,5 @@ public interface IAlumnoService {
 
     public void deleteById(Long id);
 
-    public Alumno fromDto(AlumnoRequestDto dto);
+    public Alumno fromDto(AlumnoRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IAsignacionDocenteService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IAsignacionDocenteService.java
@@ -16,5 +16,5 @@ public interface IAsignacionDocenteService {
 
     public void deleteById(Long id);
 
-    public AsignacionDocente fromDto(AsignacionDocenteRequestDto dto);
+    public AsignacionDocente fromDto(AsignacionDocenteRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IAsistenciaService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IAsistenciaService.java
@@ -16,5 +16,5 @@ public interface IAsistenciaService {
 
     public void deleteById(Long id);
 
-    public Asistencia fromDto(AsistenciaRequestDto dto);
+    public Asistencia fromDto(AsistenciaRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/ICalendarioMateriaService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/ICalendarioMateriaService.java
@@ -16,5 +16,5 @@ public interface ICalendarioMateriaService {
 
     public void deleteById(Long id);
 
-    public CalendarioMateria fromDto(CalendarioMateriaRequestDto dto);
+    public CalendarioMateria fromDto(CalendarioMateriaRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/ICarreraService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/ICarreraService.java
@@ -16,5 +16,5 @@ public interface ICarreraService {
 
     public void deleteById(Long id);
 
-    public Carrera fromDto(CarreraRequestDto dto);
+    public Carrera fromDto(CarreraRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IComisionService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IComisionService.java
@@ -16,5 +16,5 @@ public interface IComisionService {
 
     public void deleteById(Long id);
 
-    public Comision fromDto(ComisionRequestDto dto);
+    public Comision fromDto(ComisionRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/ICondicionFinalService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/ICondicionFinalService.java
@@ -16,5 +16,5 @@ public interface ICondicionFinalService {
 
     public void deleteById(Long id);
 
-    public CondicionFinal fromDto(CondicionFinalRequestDto dto);
+    public CondicionFinal fromDto(CondicionFinalRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/ICursadaService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/ICursadaService.java
@@ -16,5 +16,5 @@ public interface ICursadaService {
 
     public void deleteById(Long id);
 
-    public Cursada fromDto(CursadaRequestDto dto);
+    public Cursada fromDto(CursadaRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IDocenteService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IDocenteService.java
@@ -16,5 +16,5 @@ public interface IDocenteService {
 
     public void deleteById(Long id);
 
-    public Docente fromDto(DocenteRequestDto dto);
+    public Docente fromDto(DocenteRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IEstadoCursadaService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IEstadoCursadaService.java
@@ -16,5 +16,5 @@ public interface IEstadoCursadaService {
 
     public void deleteById(Long id);
 
-    public EstadoCursada fromDto(EstadoCursadaRequestDto dto);
+    public EstadoCursada fromDto(EstadoCursadaRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IEstadoEvaluacionService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IEstadoEvaluacionService.java
@@ -16,5 +16,5 @@ public interface IEstadoEvaluacionService {
 
     public void deleteById(Long id);
 
-    public EstadoEvaluacion fromDto(EstadoEvaluacionRequestDto dto);
+    public EstadoEvaluacion fromDto(EstadoEvaluacionRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IEvaluacionService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IEvaluacionService.java
@@ -16,5 +16,5 @@ public interface IEvaluacionService {
 
     public void deleteById(Long id);
 
-    public Evaluacion fromDto(EvaluacionRequestDto dto);
+    public Evaluacion fromDto(EvaluacionRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IHorarioService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IHorarioService.java
@@ -16,5 +16,5 @@ public interface IHorarioService {
 
     public void deleteById(Long id);
 
-    public Horario fromDto(HorarioRequestDto dto);
+    public Horario fromDto(HorarioRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IInscripcionMateriaService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IInscripcionMateriaService.java
@@ -16,5 +16,5 @@ public interface IInscripcionMateriaService {
 
     public void deleteById(Long id);
 
-    public InscripcionMateria fromDto(InscripcionMateriaRequestDto dto);
+    public InscripcionMateria fromDto(InscripcionMateriaRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IMateriaService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IMateriaService.java
@@ -16,5 +16,5 @@ public interface IMateriaService {
 
     public void deleteById(Long id);
 
-    public Materia fromDto(MateriaRequestDto dto);
+    public Materia fromDto(MateriaRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/INivelMateriaService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/INivelMateriaService.java
@@ -16,5 +16,5 @@ public interface INivelMateriaService {
 
     public void deleteById(Long id);
 
-    public NivelMateria fromDto(NivelMateriaRequestDto dto);
+    public NivelMateria fromDto(NivelMateriaRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IObservacionAlumnoService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IObservacionAlumnoService.java
@@ -16,5 +16,5 @@ public interface IObservacionAlumnoService {
 
     public void deleteById(Long id);
 
-    public ObservacionAlumno fromDto(ObservacionAlumnoRequestDto dto);
+    public ObservacionAlumno fromDto(ObservacionAlumnoRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IPeriodoLectivoService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IPeriodoLectivoService.java
@@ -16,5 +16,5 @@ public interface IPeriodoLectivoService {
 
     public void deleteById(Long id);
 
-    public PeriodoLectivo fromDto(PeriodoLectivoRequestDto dto);
+    public PeriodoLectivo fromDto(PeriodoLectivoRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IPlanEstudioService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IPlanEstudioService.java
@@ -16,5 +16,5 @@ public interface IPlanEstudioService {
 
     public void deleteById(Long id);
 
-    public PlanEstudio fromDto(PlanEstudioRequestDto dto);
+    public PlanEstudio fromDto(PlanEstudioRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IRegistroClaseService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IRegistroClaseService.java
@@ -16,5 +16,5 @@ public interface IRegistroClaseService {
 
     public void deleteById(Long id);
 
-    public RegistroClase fromDto(RegistroClaseRequestDto dto);
+    public RegistroClase fromDto(RegistroClaseRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IRequisitoMateriaService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IRequisitoMateriaService.java
@@ -16,5 +16,5 @@ public interface IRequisitoMateriaService {
 
     public void deleteById(Long id);
 
-    public RequisitoMateria fromDto(RequisitoMateriaRequestDto dto);
+    public RequisitoMateria fromDto(RequisitoMateriaRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/ISedeService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/ISedeService.java
@@ -16,5 +16,5 @@ public interface ISedeService {
 
     public void deleteById(Long id);
 
-    public Sede fromDto(SedeRequestDto dto);
+    public Sede fromDto(SedeRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/ITipoEvaluacionService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/ITipoEvaluacionService.java
@@ -16,5 +16,5 @@ public interface ITipoEvaluacionService {
 
     public void deleteById(Long id);
 
-    public TipoEvaluacion fromDto(TipoEvaluacionRequestDto dto);
+    public TipoEvaluacion fromDto(TipoEvaluacionRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/ITipoNotaService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/ITipoNotaService.java
@@ -16,5 +16,5 @@ public interface ITipoNotaService {
 
     public void deleteById(Long id);
 
-    public TipoNota fromDto(TipoNotaRequestDto dto);
+    public TipoNota fromDto(TipoNotaRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/ITurnoService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/ITurnoService.java
@@ -16,5 +16,5 @@ public interface ITurnoService {
 
     public void deleteById(Long id);
 
-    public Turno fromDto(TurnoRequestDto dto);
+    public Turno fromDto(TurnoRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/AlumnoServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/AlumnoServiceImpl.java
@@ -49,7 +49,7 @@ public class AlumnoServiceImpl implements IAlumnoService {
     }
 
     @Override
-    public Alumno fromDto(AlumnoRequestDto alumnoDto) {
+    public Alumno fromDto(AlumnoRequestDto alumnoDto) throws Exception {
         Alumno alumno = new Alumno();
         alumno.setNombre(alumnoDto.getNombre());
         alumno.setApellido(alumnoDto.getApellido());

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/AsignacionDocenteServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/AsignacionDocenteServiceImpl.java
@@ -69,11 +69,15 @@ public class AsignacionDocenteServiceImpl implements IAsignacionDocenteService {
     }
 
     @Override
-    public AsignacionDocente fromDto(AsignacionDocenteRequestDto dto) {
-        Docente docente = docenteRepository.findById(dto.getDocenteId()).orElse(null);
-        Materia materia = materiaRepository.findById(dto.getMateriaId()).orElse(null);
-        Comision comision = comisionRepository.findById(dto.getComisionId()).orElse(null);
-        PeriodoLectivo periodoLectivo = periodoLectivoRepository.findById(dto.getPeriodoLectivoId()).orElse(null);
+    public AsignacionDocente fromDto(AsignacionDocenteRequestDto dto) throws Exception {
+        Docente docente = docenteRepository.findById(dto.getDocenteId())
+                .orElseThrow(() -> new Exception("Docente no encontrado con id: " + dto.getDocenteId()));
+        Materia materia = materiaRepository.findById(dto.getMateriaId())
+                .orElseThrow(() -> new Exception("Materia no encontrada con id: " + dto.getMateriaId()));
+        Comision comision = comisionRepository.findById(dto.getComisionId())
+                .orElseThrow(() -> new Exception("Comision no encontrada con id: " + dto.getComisionId()));
+        PeriodoLectivo periodoLectivo = periodoLectivoRepository.findById(dto.getPeriodoLectivoId())
+                .orElseThrow(() -> new Exception("Periodo lectivo no encontrado con id: " + dto.getPeriodoLectivoId()));
         return new AsignacionDocente(docente, materia, comision, periodoLectivo);
     }
 }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/AsistenciaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/AsistenciaServiceImpl.java
@@ -116,4 +116,21 @@ public class AsistenciaServiceImpl implements IAsistenciaService {
             throw new Exception("Error al eliminar la asistencia: " + e.getMessage());
         }
     }
+
+    @Override
+    public Asistencia fromDto(AsistenciaRequestDto dto) throws Exception {
+        Asistencia asistencia = new Asistencia();
+        if (dto.getAlumnoId() != null) {
+            Alumno alumno = alumnoRepository.findById(dto.getAlumnoId())
+                    .orElseThrow(() -> new Exception("Alumno no encontrado con ID: " + dto.getAlumnoId()));
+            asistencia.setAlumno(alumno);
+        }
+        if (dto.getRegistroClaseId() != null) {
+            RegistroClase registro = registroClaseRepository.findById(dto.getRegistroClaseId())
+                    .orElseThrow(() -> new Exception("Registro de clase no encontrado con ID: " + dto.getRegistroClaseId()));
+            asistencia.setRegistroClase(registro);
+        }
+        asistencia.setPresente(dto.getPresente());
+        return asistencia;
+    }
 }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/CarreraServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/CarreraServiceImpl.java
@@ -52,7 +52,7 @@ public class CarreraServiceImpl implements ICarreraService {
     }
 
     @Override
-    public Carrera fromDto(CarreraRequestDto dto) {
+    public Carrera fromDto(CarreraRequestDto dto) throws Exception {
         if (dto == null) {
             return null;
         }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/ComisionServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/ComisionServiceImpl.java
@@ -51,12 +51,14 @@ public class ComisionServiceImpl implements IComisionService {
     }
 
     @Override
-    public Comision fromDto(ComisionRequestDto dto) {
+    public Comision fromDto(ComisionRequestDto dto) throws Exception {
         if (dto == null) {
             return null;
         }
-        Turno turno = turnoRepository.findById(dto.getTurnoId()).orElse(null);
-        Sede sede = sedeRepository.findById(dto.getSedeId()).orElse(null);
+        Turno turno = turnoRepository.findById(dto.getTurnoId())
+                .orElseThrow(() -> new Exception("Turno no encontrado con id: " + dto.getTurnoId()));
+        Sede sede = sedeRepository.findById(dto.getSedeId())
+                .orElseThrow(() -> new Exception("Sede no encontrada con id: " + dto.getSedeId()));
         return new Comision(dto.getNombre(), turno, sede);
     }
 }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/CondicionFinalServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/CondicionFinalServiceImpl.java
@@ -44,7 +44,7 @@ public class CondicionFinalServiceImpl implements ICondicionFinalService {
     }
 
     @Override
-    public CondicionFinal fromDto(CondicionFinalRequestDto dto) {
+    public CondicionFinal fromDto(CondicionFinalRequestDto dto) throws Exception {
         if (dto == null) {
             return null;
         }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/CursadaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/CursadaServiceImpl.java
@@ -76,3 +76,18 @@ public class CursadaServiceImpl implements ICursadaService{
             }
 
     }
+
+    @Override
+    public Cursada fromDto(CursadaRequestDto dto) throws Exception {
+        Cursada cursada = new Cursada();
+        Alumno alumno = alumnorepo.findById(dto.getAlumnoId())
+                .orElseThrow(() -> new Exception("Alumno no encontrado con id: " + dto.getAlumnoId()));
+        Materia materia = materiaRepository.findById(dto.getMateriaId())
+                .orElseThrow(() -> new Exception("Materia no encontrada con id: " + dto.getMateriaId()));
+        CondicionFinal condicionFinal = cRepository.findById(dto.getCondicionFinalId())
+                .orElseThrow(() -> new Exception("Condición final no encontrada con id: " + dto.getCondicionFinalId()));
+        cursada.setAlumno(alumno);
+        cursada.setMateria(materia);
+        cursada.setCondicionFinal(condicionFinal);
+        return cursada;
+    }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/DocenteServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/DocenteServiceImpl.java
@@ -30,7 +30,7 @@ public class DocenteServiceImpl implements IDocenteService {
     }
 
     @Override
-    public Docente fromDto(DocenteRequestDto docenteDTO) {
+    public Docente fromDto(DocenteRequestDto docenteDTO) throws Exception {
 
         Docente docente = new Docente();
         docente.setNombre(docenteDTO.getNombre());

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/EstadoCursadaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/EstadoCursadaServiceImpl.java
@@ -48,7 +48,7 @@ public class EstadoCursadaServiceImpl implements IEstadoCursadaService {
     }
 
     @Override
-    public EstadoCursada fromDto(EstadoCursadaRequestDto estadoCursadaRequestDto) {
+    public EstadoCursada fromDto(EstadoCursadaRequestDto estadoCursadaRequestDto) throws Exception {
         EstadoCursada estadoCursada = new EstadoCursada();
         estadoCursada.setNombre(estadoCursadaRequestDto.getNombre());
         estadoCursada.setDescripcion(estadoCursadaRequestDto.getDescripcion());

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/EstadoEvaluacionServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/EstadoEvaluacionServiceImpl.java
@@ -52,7 +52,7 @@ public class EstadoEvaluacionServiceImpl implements IEstadoEvaluacionService {
     }
 
     @Override
-    public EstadoEvaluacion fromDto(EstadoEvaluacionRequestDto dto) {
+    public EstadoEvaluacion fromDto(EstadoEvaluacionRequestDto dto) throws Exception {
         EstadoEvaluacion estado = new EstadoEvaluacion();
         estado.setNombre(dto.getNombre());
         estado.setDescripcion(dto.getDescripcion());

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/EvaluacionServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/EvaluacionServiceImpl.java
@@ -76,44 +76,44 @@ public class EvaluacionServiceImpl implements IEvaluacionService {
 
     // Pasar de DTO a entidad
     @Override
+    public Evaluacion fromDto(EvaluacionRequestDto evaluacionRequestDto) throws Exception {
+        if (evaluacionRequestDto == null) {
+            throw new Exception("Evaluación no puede ser nula");
+        }
+        Evaluacion evaluacion = new Evaluacion();
+
+        if (evaluacionRequestDto.getTipoEvaluacionId() != null) {
+            TipoEvaluacion tipoEvaluacion = tipoEvaluacionRepository
+                    .findById(evaluacionRequestDto.getTipoEvaluacionId())
+                    .orElseThrow(() -> new Exception(
+                            "Tipo de evaluación no encontrado con id: " + evaluacionRequestDto.getTipoEvaluacionId()));
+            evaluacion.setTipoEvaluacion(tipoEvaluacion);
+        }
+
+        if (evaluacionRequestDto.getMateriaId() != null) {
+            Materia materia = materiaRepository.findById(evaluacionRequestDto.getMateriaId())
+                    .orElseThrow(() -> new Exception(
+                            "Materia no encontrada con id: " + evaluacionRequestDto.getMateriaId()));
+            evaluacion.setMateria(materia);
+        }
+
+        if (evaluacionRequestDto.getComisionId() != null) {
+            Comision comision = comisionRepository.findById(evaluacionRequestDto.getComisionId())
+                    .orElseThrow(() -> new Exception(
+                            "Comisión no encontrada con id: " + evaluacionRequestDto.getComisionId()));
+            evaluacion.setComision(comision);
+        }
+        evaluacion.setId(evaluacionRequestDto.getId());
+        evaluacion.setFecha(evaluacionRequestDto.getFechaEvaluacion());
+        return evaluacion;
+    }
+
     public Evaluacion convertToEntity(EvaluacionRequestDto evaluacionRequestDto) {
         try {
-            if (evaluacionRequestDto == null) {
-                throw new RuntimeException("Evaluación no puede ser nula");
-            }
-            Evaluacion evaluacion = new Evaluacion();
-
-            if (evaluacionRequestDto.getTipoEvaluacionId() != null) {
-                TipoEvaluacion tipoEvaluacion = tipoEvaluacionRepository
-                        .findById(evaluacionRequestDto.getTipoEvaluacionId()).orElse(null);
-                if (tipoEvaluacion == null) {
-                    throw new RuntimeException("Tipo de evaluación no encontrado");
-                }
-                evaluacion.setTipoEvaluacion(tipoEvaluacion);
-            }
-
-            if (evaluacionRequestDto.getMateriaId() != null) {
-                Materia materia = materiaRepository.findById(evaluacionRequestDto.getMateriaId()).orElse(null);
-                if (materia == null) {
-                    throw new RuntimeException("Materia no encontrada");
-                }
-                evaluacion.setMateria(materia);
-            }
-
-            if (evaluacionRequestDto.getComisionId() != null) {
-                Comision comision = comisionRepository.findById(evaluacionRequestDto.getComisionId()).orElse(null);
-                if (comision == null) {
-                    throw new RuntimeException("Comisión no encontrada");
-                }
-                evaluacion.setComision(comision);
-            }
-                        evaluacion.setId(evaluacionRequestDto.getId());
-                        evaluacion.setFecha(evaluacionRequestDto.getFechaEvaluacion());
-            return evaluacion;
+            return fromDto(evaluacionRequestDto);
         } catch (Exception e) {
             throw new RuntimeException("Error: " + e.getMessage());
         }
-
     }
 
     @Override

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/HorarioServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/HorarioServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 import com.imb2025.calificaciones.entity.Horario;
 import com.imb2025.calificaciones.repository.HorarioRepository;
+import com.imb2025.calificaciones.repository.ComisionRepository;
 import com.imb2025.calificaciones.service.IHorarioService;
 
 @Service
@@ -14,35 +15,44 @@ public class HorarioServiceImpl implements IHorarioService{
     @Autowired
     private HorarioRepository horarioRepository;
 
-    @Override
-    public List<Horario> getAll() {
+    @Autowired
+    private ComisionRepository comisionRepository;
 
+    @Override
+    public List<Horario> findAll() {
         return horarioRepository.findAll();
     }
 
     @Override
-    public Horario save(Horario nuevoHorario) {
-
+    public Horario create(Horario nuevoHorario) {
         return horarioRepository.save(nuevoHorario);
     }
 
     @Override
     public Horario update(Horario datosActualizados, Long id) {
-
         return horarioRepository.save(datosActualizados);
     }
 
     @Override
-    public void delete(Long id) {
-
+    public void deleteById(Long id) {
         horarioRepository.deleteById(id);
-
     }
 
     @Override
     public Horario findById(Long id) {
-
         return horarioRepository.findById(id).orElse(null);
     }
 
+    @Override
+    public Horario fromDto(HorarioRequestDto dto) throws Exception {
+        Horario horario = new Horario();
+        if (dto.getComisionId() != null) {
+            horario.setComision(comisionRepository.findById(dto.getComisionId())
+                    .orElseThrow(() -> new Exception("Comision no encontrada con id: " + dto.getComisionId())));
+        }
+        horario.setDiaSemana(dto.getDiaSemana());
+        horario.setHoraInicio(dto.getHoraInicio());
+        horario.setHoraFin(dto.getHoraFin());
+        return horario;
+    }
 }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/InscripcionMateriaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/InscripcionMateriaServiceImpl.java
@@ -1,7 +1,6 @@
 package com.imb2025.calificaciones.service.jpa;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -59,21 +58,21 @@ public class InscripcionMateriaServiceImpl implements IInscripcionMateriaService
     }
 
     @Override
-    public InscripcionMateria fromDto(InscripcionMateriaRequestDto inscripcionMateriaDTO) {
+    public InscripcionMateria fromDto(InscripcionMateriaRequestDto inscripcionMateriaDTO) throws Exception {
         InscripcionMateria inscripcionMateria = new InscripcionMateria();
 
         Alumno alumno = alumnoRepository.findById(inscripcionMateriaDTO.getIdAlumno())
-                .orElseThrow(() -> new NoSuchElementException(
+                .orElseThrow(() -> new Exception(
                         "Alumno no encontrado con ID: " + inscripcionMateriaDTO.getIdAlumno()));
         inscripcionMateria.setAlumno(alumno);
 
         Materia materia = materiaRepository.findById(inscripcionMateriaDTO.getIdMateria())
-                .orElseThrow(() -> new NoSuchElementException(
+                .orElseThrow(() -> new Exception(
                         "Materia no encontrada con ID: " + inscripcionMateriaDTO.getIdMateria()));
         inscripcionMateria.setMateria(materia);
 
         PeriodoLectivo periodoLectivo = periodoLectivoRepository.findById(inscripcionMateriaDTO.getIdPeriodoLectivo())
-                .orElseThrow(() -> new NoSuchElementException(
+                .orElseThrow(() -> new Exception(
                         "Periodo Lectivo no encontrado con ID: " + inscripcionMateriaDTO.getIdPeriodoLectivo()));
         inscripcionMateria.setPeriodoLectivo(periodoLectivo);
 

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/NivelMateriaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/NivelMateriaServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import com.imb2025.calificaciones.dto.NivelMateriaRequestDto;
 import com.imb2025.calificaciones.entity.NivelMateria;
 import com.imb2025.calificaciones.repository.NivelMateriaRepository;
 import com.imb2025.calificaciones.service.INivelMateriaService;
@@ -35,6 +36,17 @@ public class NivelMateriaServiceImpl implements INivelMateriaService {
     public void deleteById(Long id) {
         repo.deleteById(id);
 
+    }
+
+    @Override
+    public NivelMateria fromDto(NivelMateriaRequestDto dto) throws Exception {
+        if (dto == null) {
+            throw new Exception("El dto de nivel materia no puede ser nulo");
+        }
+        NivelMateria nivelMateria = new NivelMateria();
+        nivelMateria.setNombre(dto.getNombre());
+        nivelMateria.setDescripcion(dto.getDescripcion());
+        return nivelMateria;
     }
 
     }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/ObservacionAlumnoServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/ObservacionAlumnoServiceImpl.java
@@ -81,12 +81,13 @@ public class ObservacionAlumnoServiceImpl implements IObservacionAlumnoService{
 
     }
 
-    public ObservacionAlumno fromDTO(ObservacionAlumnoRequestDto dto) {
+    @Override
+    public ObservacionAlumno fromDto(ObservacionAlumnoRequestDto dto) throws Exception {
         Docente docente = docenteRepository.findById(dto.getDocenteId())
-                .orElseThrow(() -> new RuntimeException("docente no encontrado"));
+                .orElseThrow(() -> new Exception("docente no encontrado"));
 
         Alumno alumno = alumnoRepository.findById(dto.getAlumnoId())
-                .orElseThrow(() -> new RuntimeException("alumno no encontrado"));
+                .orElseThrow(() -> new Exception("alumno no encontrado"));
 
         ObservacionAlumno observacion = new ObservacionAlumno();
         observacion.setFecha(dto.getFecha());

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/PeriodoLectivoServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/PeriodoLectivoServiceImpl.java
@@ -49,7 +49,7 @@ public class PeriodoLectivoServiceImpl implements IPeriodoLectivoService{
     }
 
     @Override
-    public PeriodoLectivo fromDto(PeriodoLectivoRequestDto requestDTO) {
+    public PeriodoLectivo fromDto(PeriodoLectivoRequestDto requestDTO) throws Exception {
         PeriodoLectivo periodoLectivo = new PeriodoLectivo();
 
         periodoLectivo.setNombre(requestDTO.getNombre());

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/PlanEstudioServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/PlanEstudioServiceImpl.java
@@ -88,36 +88,30 @@ public class PlanEstudioServiceImpl implements IPlanEstudioService {
     }
 
     @Override
-    public PlanEstudio convertToEntity(PlanEstudioRequestDto dto) {
+    public PlanEstudio fromDto(PlanEstudioRequestDto dto) throws Exception {
         if (dto == null) {
-            throw new RuntimeException("El DTO no puede ser nulo");
+            throw new Exception("El DTO no puede ser nulo");
         }
 
         PlanEstudio plan = new PlanEstudio();
 
-        // Validar carrera
         Carrera carrera = carreraRepository.findById(dto.getCarreraId())
-            .orElseThrow(() -> new EntidadNoEncontradaException("Carrera con ID " + dto.getCarreraId() + " no encontrada"));
+            .orElseThrow(() -> new Exception("Carrera con ID " + dto.getCarreraId() + " no encontrada"));
         plan.setCarrera(carrera);
 
-        // Validar nombre
         if (dto.getNombre() == null || dto.getNombre().isEmpty()) {
-            throw new RuntimeException("El nombre no puede ser nulo o vacío");
+            throw new Exception("El nombre no puede ser nulo o vacío");
         }
         plan.setNombre(dto.getNombre());
-
-        // Validar año vigencia
-        /*
-        AnioVigencia anio = anioVigenciaRepository.findById(dto.getAniovigencia())
-            .orElseThrow(() -> new EntidadNoEncontradaException("Año de vigencia con ID " + dto.getAniovigencia() + " no encontrado"));
-        plan.setAnioVigencia(anio);
-        */
-
-        // Si viene el ID (por PUT)
-        if (dto.getId() != null) {
-            plan.setId(dto.getId());
-        }
-
+        plan.setAnioVigencia(dto.getAnioVigencia());
         return plan;
+    }
+
+    public PlanEstudio convertToEntity(PlanEstudioRequestDto dto) {
+        try {
+            return fromDto(dto);
+        } catch (Exception e) {
+            throw new RuntimeException("Error al convertir PlanEstudio: " + e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/RegistroClaseServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/RegistroClaseServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import com.imb2025.calificaciones.exception.EntidadNoEncontradaException;
 import com.imb2025.calificaciones.dto.RegistroClaseDTO;
+import com.imb2025.calificaciones.dto.RegistroClaseRequestDto;
 import com.imb2025.calificaciones.entity.Comision;
 import com.imb2025.calificaciones.entity.Docente;
 import com.imb2025.calificaciones.entity.RegistroClase;
@@ -82,5 +83,19 @@ public class RegistroClaseServiceImpl implements IRegistroClaseService {
         registro.setComision(comision);
 
         return registroClaseRepository.save(registro);
+    }
+
+    @Override
+    public RegistroClase fromDto(RegistroClaseRequestDto dto) throws Exception {
+        Docente docente = docenteRepository.findById(dto.getDocenteId())
+                .orElseThrow(() -> new Exception("Docente no encontrado con ID: " + dto.getDocenteId()));
+        Comision comision = comisionRepository.findById(dto.getComisionId())
+                .orElseThrow(() -> new Exception("Comisión no encontrada con ID: " + dto.getComisionId()));
+        RegistroClase registro = new RegistroClase();
+        registro.setFecha(dto.getFecha());
+        registro.setTema(dto.getTema());
+        registro.setDocente(docente);
+        registro.setComision(comision);
+        return registro;
     }
 }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/RequisitoMateriaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/RequisitoMateriaServiceImpl.java
@@ -6,7 +6,6 @@ import com.imb2025.calificaciones.entity.RequisitoMateria;
 import com.imb2025.calificaciones.repository.MateriaRepository;
 import com.imb2025.calificaciones.repository.RequisitoMateriaRepository;
 import com.imb2025.calificaciones.service.IRequisitoMateriaService;
-import com.imb2025.calificaciones.exception.EntidadNoEncontradaException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -35,11 +34,8 @@ public class RequisitoMateriaServiceImpl implements IRequisitoMateriaService {
     @Override
     public RequisitoMateria save(RequisitoMateriaRequestDto dto) {
         try {
-            // 🆕 Línea 38 → se delega la conversión del DTO a entidad
-            RequisitoMateria requisito = mapearDesdeDto(dto);
-            return requisitoRepository.save(requisito); // Línea 39
-        } catch (EntidadNoEncontradaException e) {
-            throw e;
+            RequisitoMateria requisito = fromDto(dto);
+            return requisitoRepository.save(requisito);
         } catch (Exception e) {
             throw new RuntimeException("Error al guardar requisito: " + e.getMessage());
         }
@@ -51,7 +47,7 @@ public class RequisitoMateriaServiceImpl implements IRequisitoMateriaService {
             RequisitoMateria existente = requisitoRepository.findById(id)
                 .orElseThrow(() -> new EntidadNoEncontradaException("Requisito con ID " + id + " no encontrado."));
 
-            RequisitoMateria actualizado = mapearDesdeDto(dto); // 🆕 Línea 53
+            RequisitoMateria actualizado = fromDto(dto);
             existente.setMateria(actualizado.getMateria());
             existente.setMateriaCorrelativa(actualizado.getMateriaCorrelativa());
 
@@ -68,14 +64,12 @@ public class RequisitoMateriaServiceImpl implements IRequisitoMateriaService {
         requisitoRepository.deleteById(id);
     }
 
-    //  Método nuevo prueba
-    private RequisitoMateria mapearDesdeDto(RequisitoMateriaRequestDto dto) {
+    @Override
+    public RequisitoMateria fromDto(RequisitoMateriaRequestDto dto) throws Exception {
         Materia materia = materiaRepository.findById(dto.getMateriaId())
-            .orElseThrow(() -> new EntidadNoEncontradaException("Materia con ID " + dto.getMateriaId() + " no encontrada."));
-
+                .orElseThrow(() -> new Exception("Materia con ID " + dto.getMateriaId() + " no encontrada."));
         Materia correlativa = materiaRepository.findById(dto.getMateriaRequeridaId())
-            .orElseThrow(() -> new EntidadNoEncontradaException("Materia correlativa con ID " + dto.getMateriaRequeridaId() + " no encontrada."));
-
+                .orElseThrow(() -> new Exception("Materia correlativa con ID " + dto.getMateriaRequeridaId() + " no encontrada."));
         RequisitoMateria entidad = new RequisitoMateria();
         entidad.setMateria(materia);
         entidad.setMateriaCorrelativa(correlativa);

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/SedeServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/SedeServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import com.imb2025.calificaciones.dto.SedeRequestDto;
 import com.imb2025.calificaciones.entity.Sede;
 import com.imb2025.calificaciones.repository.SedeRepository;
 import com.imb2025.calificaciones.service.ISedeService;
@@ -41,5 +42,16 @@ public class SedeServiceImpl implements ISedeService {
     public void deletedById(Long id) {
         repo.deleteById(id);
 
+    }
+
+    @Override
+    public Sede fromDto(SedeRequestDto dto) throws Exception {
+        if (dto == null) {
+            throw new Exception("El dto de sede no puede ser nulo");
+        }
+        Sede sede = new Sede();
+        sede.setNombre(dto.getNombre());
+        sede.setDireccion(dto.getDireccion());
+        return sede;
     }
 }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/TipoEvaluacionServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/TipoEvaluacionServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import com.imb2025.calificaciones.dto.TipoEvaluacionRequestDto;
 import com.imb2025.calificaciones.entity.TipoEvaluacion;
 import com.imb2025.calificaciones.repository.TipoEvaluacionRepository;
 import com.imb2025.calificaciones.service.ITipoEvaluacionService;
@@ -47,6 +48,17 @@ public class TipoEvaluacionServiceImpl implements ITipoEvaluacionService {
             throw new RuntimeException("No existe el tipo de evaluación con ID " + id);
         }
         repo.deleteById(id);
+    }
+
+    @Override
+    public TipoEvaluacion fromDto(TipoEvaluacionRequestDto dto) throws Exception {
+        if (dto == null) {
+            throw new Exception("El dto de tipo evaluación no puede ser nulo");
+        }
+        TipoEvaluacion tipo = new TipoEvaluacion();
+        tipo.setNombre(dto.getNombre());
+        tipo.setDescripcion(dto.getDescripcion());
+        return tipo;
     }
 
 }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/TipoNotaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/TipoNotaServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import com.imb2025.calificaciones.dto.TipoNotaRequestDto;
 import com.imb2025.calificaciones.entity.TipoNota;
 import com.imb2025.calificaciones.repository.TipoNotaRepository;
 import com.imb2025.calificaciones.service.ITipoNotaService;
@@ -53,5 +54,16 @@ public class TipoNotaServiceImpl implements ITipoNotaService {
     @Override
     public void deleteById(Long id) {
         tipoNotaRepository.deleteById(id);
+    }
+
+    @Override
+    public TipoNota fromDto(TipoNotaRequestDto dto) throws Exception {
+        if (dto == null) {
+            throw new Exception("El dto de tipo nota no puede ser nulo");
+        }
+        TipoNota tipoNota = new TipoNota();
+        tipoNota.setNombre(dto.getNombre());
+        tipoNota.setDescripcion(dto.getDescripcion());
+        return tipoNota;
     }
 }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/TurnoServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/TurnoServiceImpl.java
@@ -51,7 +51,7 @@ public class TurnoServiceImpl implements ITurnoService {
     }
 
     @Override
-    public Turno fromDto(TurnoRequestDto turnoRequestDto) {
+    public Turno fromDto(TurnoRequestDto turnoRequestDto) throws Exception {
         Turno turno = new Turno();
         turno.setNombre(turnoRequestDto.getNombre());
         turno.setHoraInicio(turnoRequestDto.getHoraInicio());


### PR DESCRIPTION
## Summary
- implement `fromDto` across JPA services and expose in service interfaces
- validate related entities when converting DTOs, throwing checked exceptions on missing foreign keys
- unify DTO-to-entity conversions with reusable helpers

## Testing
- `mvn -q -e -DskipTests compile` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a134f9975c832fbac705e0322c1d0f