### PR TITLE
Fix RegistroClase service findAll implementation

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/controller/RegistroClaseController.java
+++ b/src/main/java/com/imb2025/calificaciones/controller/RegistroClaseController.java
@@ -31,8 +31,8 @@ public class RegistroClaseController {
     }
 
     @GetMapping("/obteneregistros")
-    public ResponseEntity<List<RegistroClase>> obtenerTodosLosRegistros() {
-        List<RegistroClase> registros = iregistroClase.obtenerTodosLosRegistros();
+    public ResponseEntity<List<RegistroClase>> findAll() {
+        List<RegistroClase> registros = iregistroClase.findAll();
         if (registros.isEmpty()) {
             return ResponseEntity.noContent().build(); // 204 No Content
         }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/RegistroClaseServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/RegistroClaseServiceImpl.java
@@ -31,7 +31,7 @@ public class RegistroClaseServiceImpl implements IRegistroClaseService {
     }
 
     @Override
-    public List<RegistroClase> obtenerTodosLosRegistros() {
+    public List<RegistroClase> findAll() {
         return registroClaseRepository.findAll();
     }
 


### PR DESCRIPTION
## Summary
- Rename `obtenerTodosLosRegistros` to `findAll` in `RegistroClaseServiceImpl` and delegate to `registroClaseRepository.findAll`
- Update `RegistroClaseController` to call the new `findAll` method

## Testing
- `mvn -q -e -DskipTests compile` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a138bdf978832fb06b04d38f3ce983