### PR TITLE
Normalize findById implementations across services

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/controller/ObservacionAlumnoController.java
+++ b/src/main/java/com/imb2025/calificaciones/controller/ObservacionAlumnoController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.RestController;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -49,35 +48,35 @@ public class ObservacionAlumnoController {
 	}
 	
 	@GetMapping("/{id}")
-	public ResponseEntity<?> getById(@PathVariable Long id, HttpServletRequest request) {
-		
-		Optional<ObservacionAlumno> observacionAlumno = observacionAlumnoService.findById(id);
-		
-		if (observacionAlumno.isPresent()) {
-			
-			SuccessResponseDto<ObservacionAlumno> response = new SuccessResponseDto<>();
-			response.setTimestamp(LocalDateTime.now());
-			response.setStatus(HttpStatus.OK.value());
-			response.setMessage("observación obtenida correctamente por ID");
-			response.setData(observacionAlumno.get());
-			
-			return ResponseEntity.ok(response);
-			
-		} else {
-			
-			ErrorResponseDto errorResponse = new ErrorResponseDto();
-			errorResponse.setTimestamp(LocalDateTime.now());
-			errorResponse.setStatus(HttpStatus.NO_CONTENT.value());
-			errorResponse.setError("Not found");
-			errorResponse.setMessages(Arrays.asList(
-					new ErrorMessage("id", "Observación no encontrada con ID: " + id)
+        public ResponseEntity<?> getById(@PathVariable Long id, HttpServletRequest request) {
+
+                ObservacionAlumno observacionAlumno = observacionAlumnoService.findById(id);
+
+                if (observacionAlumno != null) {
+
+                        SuccessResponseDto<ObservacionAlumno> response = new SuccessResponseDto<>();
+                        response.setTimestamp(LocalDateTime.now());
+                        response.setStatus(HttpStatus.OK.value());
+                        response.setMessage("observación obtenida correctamente por ID");
+                        response.setData(observacionAlumno);
+
+                        return ResponseEntity.ok(response);
+
+                } else {
+
+                        ErrorResponseDto errorResponse = new ErrorResponseDto();
+                        errorResponse.setTimestamp(LocalDateTime.now());
+                        errorResponse.setStatus(HttpStatus.NO_CONTENT.value());
+                        errorResponse.setError("Not found");
+                        errorResponse.setMessages(Arrays.asList(
+                                        new ErrorMessage("id", "Observación no encontrada con ID: " + id)
             ));
-			errorResponse.setErrorCode("OBSERVACION_NOT_FOUND");
-			errorResponse.setPath(request.getRequestURI());
-			
-			return ResponseEntity.status(HttpStatus.NO_CONTENT).body(errorResponse);
-		}
-	}
+                        errorResponse.setErrorCode("OBSERVACION_NOT_FOUND");
+                        errorResponse.setPath(request.getRequestURI());
+
+                        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(errorResponse);
+                }
+        }
 	
 	@PostMapping
 	public ResponseEntity<?> create(@RequestBody ObservacionAlumnoRequestDto dto, HttpServletRequest request) {

--- a/src/main/java/com/imb2025/calificaciones/controller/RegistroClaseController.java
+++ b/src/main/java/com/imb2025/calificaciones/controller/RegistroClaseController.java
@@ -41,7 +41,7 @@ public class RegistroClaseController {
 
     @GetMapping("/registroclase/{id}")
     public ResponseEntity<RegistroClase> obtenerRegistroPorId(@PathVariable Long id) {
-        RegistroClase registro = iregistroClase.obtenerRegistro(id);
+        RegistroClase registro = iregistroClase.findById(id);
         return ResponseEntity.ok(registro); // Si no existe, el servicio debe lanzar excepción
     }
 

--- a/src/main/java/com/imb2025/calificaciones/controller/RequisitoMateriaController.java
+++ b/src/main/java/com/imb2025/calificaciones/controller/RequisitoMateriaController.java
@@ -19,7 +19,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import jakarta.validation.Valid;
 import java.util.List;
-import java.util.Optional;
 
 @RestController
 @RequestMapping("/requisito-materia")
@@ -35,12 +34,12 @@ public class RequisitoMateriaController {
 
     @GetMapping("/{id}")
     public ResponseEntity<?> getById(@PathVariable Long id) {
-        Optional<RequisitoMateria> requisito = service.findById(id);
-        if (requisito.isEmpty()) {
+        RequisitoMateria requisito = service.findById(id);
+        if (requisito == null) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
                     .body("El requisito con ID " + id + " no existe.");
         }
-        return ResponseEntity.ok(requisito.get());
+        return ResponseEntity.ok(requisito);
     }
 
     @PostMapping
@@ -56,8 +55,8 @@ public class RequisitoMateriaController {
 
     @PutMapping("/{id}")
     public ResponseEntity<?> update(@PathVariable Long id, @RequestBody @Valid RequisitoMateriaRequestDto dto) {
-        Optional<RequisitoMateria> existente = service.findById(id);
-        if (existente.isEmpty()) {
+        RequisitoMateria existente = service.findById(id);
+        if (existente == null) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
                     .body("No se encontró un requisito con el ID " + id + " para actualizar.");
         }
@@ -73,8 +72,8 @@ public class RequisitoMateriaController {
 
     @DeleteMapping("/{id}")
     public ResponseEntity<?> delete(@PathVariable Long id) {
-        Optional<RequisitoMateria> existente = service.findById(id);
-        if (existente.isEmpty()) {
+        RequisitoMateria existente = service.findById(id);
+        if (existente == null) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
                     .body("No se encontró el requisito con ID " + id + " para eliminar.");
         }

--- a/src/main/java/com/imb2025/calificaciones/service/IRegistroClaseService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IRegistroClaseService.java
@@ -1,6 +1,7 @@
 package com.imb2025.calificaciones.service;
 
 import com.imb2025.calificaciones.dto.RegistroClaseRequestDto;
+import com.imb2025.calificaciones.dto.RegistroClaseDTO;
 import com.imb2025.calificaciones.entity.RegistroClase;
 import java.util.List;
 
@@ -8,13 +9,13 @@ public interface IRegistroClaseService {
 
     public List<RegistroClase> findAll();
 
-    public RegistroClase create(RegistroClase registroClase);
+    public RegistroClase registrarClase(RegistroClaseDTO dto);
 
-    public RegistroClase update(RegistroClase registroClase, Long id);
+    public RegistroClase actualizarRegistro(Long id, RegistroClaseDTO dto);
 
     public RegistroClase findById(Long id);
 
-    public void deleteById(Long id);
+    public void eliminarRegistro(Long id);
 
     public RegistroClase fromDto(RegistroClaseRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/AlumnoServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/AlumnoServiceImpl.java
@@ -31,7 +31,7 @@ public class AlumnoServiceImpl implements IAlumnoService {
 
     @Override
     public Alumno findById(Long id) {
-        return alumnoRepository.findById(id).orElseThrow(() -> new RuntimeException("Estudiante no encontrado"));
+        return alumnoRepository.findById(id).orElse(null);
     }
 
     @Override

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/CalendarioMateriaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/CalendarioMateriaServiceImpl.java
@@ -31,7 +31,7 @@ public class CalendarioMateriaServiceImpl implements ICalendarioMateriaService {
     @Override
     @Transactional
     public CalendarioMateria findById(Long id) {
-        return calMatRepo.findById(id).orElseThrow();
+        return calMatRepo.findById(id).orElse(null);
     }
 
     @Override

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/ObservacionAlumnoServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/ObservacionAlumnoServiceImpl.java
@@ -28,8 +28,8 @@ public class ObservacionAlumnoServiceImpl implements IObservacionAlumnoService{
     private DocenteRepository docenteRepository;
 
     @Override
-    public Optional<ObservacionAlumno> findById(Long id) {
-        return observacionAlumnoRepository.findById(id);
+    public ObservacionAlumno findById(Long id) {
+        return observacionAlumnoRepository.findById(id).orElse(null);
     }
 
     @Override

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/RegistroClaseServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/RegistroClaseServiceImpl.java
@@ -36,9 +36,8 @@ public class RegistroClaseServiceImpl implements IRegistroClaseService {
     }
 
     @Override
-    public RegistroClase obtenerRegistro(Long id) {
-        return registroClaseRepository.findById(id)
-                .orElseThrow(() -> new EntidadNoEncontradaException("RegistroClase no encontrado con ID: " + id));
+    public RegistroClase findById(Long id) {
+        return registroClaseRepository.findById(id).orElse(null);
     }
 
     @Override

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/RequisitoMateriaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/RequisitoMateriaServiceImpl.java
@@ -6,11 +6,11 @@ import com.imb2025.calificaciones.entity.RequisitoMateria;
 import com.imb2025.calificaciones.repository.MateriaRepository;
 import com.imb2025.calificaciones.repository.RequisitoMateriaRepository;
 import com.imb2025.calificaciones.service.IRequisitoMateriaService;
+import com.imb2025.calificaciones.exception.EntidadNoEncontradaException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 public class RequisitoMateriaServiceImpl implements IRequisitoMateriaService {
@@ -27,8 +27,8 @@ public class RequisitoMateriaServiceImpl implements IRequisitoMateriaService {
     }
 
     @Override
-    public Optional<RequisitoMateria> findById(Long id) {
-        return requisitoRepository.findById(id);
+    public RequisitoMateria findById(Long id) {
+        return requisitoRepository.findById(id).orElse(null);
     }
 
     @Override

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/TipoEvaluacionServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/TipoEvaluacionServiceImpl.java
@@ -23,8 +23,7 @@ public class TipoEvaluacionServiceImpl implements ITipoEvaluacionService {
 
     @Override
     public TipoEvaluacion findById(Long id) {
-        return repo.findById(id)
-                .orElseThrow(() -> new RuntimeException("No se encontró el Tipo de Evaluacion con ID " + id));
+        return repo.findById(id).orElse(null);
     }
 
     @Override

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/TipoNotaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/TipoNotaServiceImpl.java
@@ -24,8 +24,7 @@ public class TipoNotaServiceImpl implements ITipoNotaService {
 
     @Override
     public TipoNota findById(Long id) {
-        return tipoNotaRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("TipoNota no encontrada con id: " + id));
+        return tipoNotaRepository.findById(id).orElse(null);
     }
 
     @Override

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/TurnoServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/TurnoServiceImpl.java
@@ -22,7 +22,7 @@ public class TurnoServiceImpl implements ITurnoService {
 
     @Override
     public Turno findById(Long id) {
-        return turnoRepository.findById(id).orElseThrow(() -> new RuntimeException("Turno no encontrado"));
+        return turnoRepository.findById(id).orElse(null);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Standardized `findById` across JPA services to return `repo.findById(id).orElse(null)`
- Renamed `RegistroClaseService` lookup method to `findById` and updated its interface and controllers
- Revised ObservacionAlumno and RequisitoMateria services and controllers to return entities instead of Optionals

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a13b63ee28832fb159304a0161e81c