### PR TITLE
Rename save methods to create across services

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/controller/AsistenciaController.java
+++ b/src/main/java/com/imb2025/calificaciones/controller/AsistenciaController.java
@@ -45,7 +45,7 @@ public class AsistenciaController {
     @PostMapping
     public ResponseEntity<?> create(@RequestBody AsistenciaRequestDto dto) {
         try {
-            Asistencia nueva = asistenciaService.save(dto);
+            Asistencia nueva = asistenciaService.create(dto);
             return ResponseEntity.ok(nueva);
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(e.getMessage());
@@ -56,7 +56,7 @@ public class AsistenciaController {
     @PutMapping("/{id}")
     public ResponseEntity<?> update(@PathVariable Long id, @RequestBody AsistenciaRequestDto dto) {
         try {
-            Asistencia actualizada = asistenciaService.update(id, dto);
+            Asistencia actualizada = asistenciaService.update(dto, id);
             return ResponseEntity.ok(actualizada);
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(e.getMessage());

--- a/src/main/java/com/imb2025/calificaciones/controller/ComisionController.java
+++ b/src/main/java/com/imb2025/calificaciones/controller/ComisionController.java
@@ -39,17 +39,17 @@ public class ComisionController {
 	    }
 
 	    @PostMapping
-	    public ResponseEntity<Comision> create(@RequestBody Comision comision) {
-	    	Comision createdComision = ComisionService.save(comision);
-	        return ResponseEntity.ok(createdComision);
-	    }
+            public ResponseEntity<Comision> create(@RequestBody Comision comision) {
+                Comision createdComision = ComisionService.create(comision);
+                return ResponseEntity.ok(createdComision);
+            }
 
 	    @PutMapping("/{id}")
-	    public ResponseEntity<Comision> update(@PathVariable Long id,
-	            @RequestBody Comision comision) {
-	    	Comision updatedComision = ComisionService.update(id, comision);
-	        return ResponseEntity.ok(updatedComision);
-	    }
+            public ResponseEntity<Comision> update(@PathVariable Long id,
+                    @RequestBody Comision comision) {
+                Comision updatedComision = ComisionService.update(comision, id);
+                return ResponseEntity.ok(updatedComision);
+            }
 
 	    @DeleteMapping("/{id}")
 	    public ResponseEntity<Void> delete(@PathVariable Long id) {

--- a/src/main/java/com/imb2025/calificaciones/controller/CursadaController.java
+++ b/src/main/java/com/imb2025/calificaciones/controller/CursadaController.java
@@ -37,12 +37,12 @@ public class CursadaController {
 
     @PostMapping("/api/cursada")
     public ResponseEntity<String> createCursada(@RequestBody CursadaRequestDto cursada){
-        return ResponseEntity.ok(cursadaService.save(cursada));
-    } 
+        return ResponseEntity.ok(cursadaService.create(cursada));
+    }
 
     @PutMapping("/api/cursada")
     public ResponseEntity<String> updateCursada(@RequestBody CursadaRequestDto cursada){
-        return ResponseEntity.ok(cursadaService.save(cursada));
+        return ResponseEntity.ok(cursadaService.create(cursada));
 
     }
 
@@ -55,7 +55,7 @@ public class CursadaController {
     @PutMapping("/api/cursada/{id}")
     public ResponseEntity<String> update(@PathVariable Long id, @RequestBody CursadaRequestDto dto) {
         try {
-            return ResponseEntity.ok(cursadaService.update(id,dto));
+            return ResponseEntity.ok(cursadaService.update(dto,id));
         } catch (Exception e) {
             return ResponseEntity.status(404).body("No existe la cursada");
         }

--- a/src/main/java/com/imb2025/calificaciones/controller/HorarioController.java
+++ b/src/main/java/com/imb2025/calificaciones/controller/HorarioController.java
@@ -22,25 +22,25 @@ public class HorarioController {
 	
 	@Autowired
 	private IHorarioService horarioService;
-	@GetMapping ("/entidad")
+        @GetMapping ("/entidad")
     public List<Horario> obtenerTodos() {
-        return horarioService.getAll();
+        return horarioService.findAll();
     }
 	
-	@PostMapping("/entidad")
-	public Horario crear(@RequestBody Horario nuevoHorario) {
-	    return horarioService.save(nuevoHorario);
-	}
+        @PostMapping("/entidad")
+        public Horario crear(@RequestBody Horario nuevoHorario) {
+            return horarioService.create(nuevoHorario);
+        }
 	
-	@PutMapping("/entidad/{id}")
-	public Horario actualizar(@PathVariable Long id, @RequestBody Horario datosActualizados) {
-	    return horarioService.update(id, datosActualizados);
-	}
+        @PutMapping("/entidad/{id}")
+        public Horario actualizar(@PathVariable Long id, @RequestBody Horario datosActualizados) {
+            return horarioService.update(datosActualizados, id);
+        }
 	
-	@DeleteMapping("/entidad/{id}")
-	public void eliminar(@PathVariable Long id) {
-	    horarioService.delete(id);
-	}
+        @DeleteMapping("/entidad/{id}")
+        public void eliminar(@PathVariable Long id) {
+            horarioService.deleteById(id);
+        }
 	
 	@GetMapping("/entidad/{id}")
     public Horario obtenerPorId(@PathVariable Long id){

--- a/src/main/java/com/imb2025/calificaciones/controller/NivelMateriaController.java
+++ b/src/main/java/com/imb2025/calificaciones/controller/NivelMateriaController.java
@@ -31,14 +31,14 @@ public class NivelMateriaController {
 	 public NivelMateria getNivelMateriaById(@PathVariable("id")Long id) {
 	        return nivelMateriaService.findById(id);  
 	 }       
-	 @PostMapping("/api/nivelmateria")
-	 public NivelMateria createNivelMateria(@RequestBody NivelMateria nivelMateria){
-		 return nivelMateriaService.save(nivelMateria);
-	 }
-	 @PutMapping("/api/nivelmateria")
-	 public NivelMateria updateNivelMateria(@RequestBody NivelMateria nivelMateria){
-		 return nivelMateriaService.save(nivelMateria);
-	 }
+         @PostMapping("/api/nivelmateria")
+         public NivelMateria createNivelMateria(@RequestBody NivelMateria nivelMateria){
+                 return nivelMateriaService.create(nivelMateria);
+         }
+         @PutMapping("/api/nivelmateria")
+         public NivelMateria updateNivelMateria(@RequestBody NivelMateria nivelMateria){
+                 return nivelMateriaService.update(nivelMateria, nivelMateria.getId());
+         }
 	 @DeleteMapping("/api/nivelmateria/{id}")
 	 public void deleteNivelMateria(@PathVariable("id")Long id) {
 		 nivelMateriaService.deleteById(id);

--- a/src/main/java/com/imb2025/calificaciones/controller/SedeController.java
+++ b/src/main/java/com/imb2025/calificaciones/controller/SedeController.java
@@ -37,15 +37,15 @@ public class SedeController {
 		return sedeService.findById(id);
 	}
 	
-	@PostMapping("/api/sede")
-	public Sede createSede(@RequestBody Sede sede){
-		return sedeService.save(sede);
-	}
-	
-	@PutMapping("/api/sede")
-	public Sede updateSede(@RequestBody Sede sede){
-		return sedeService.save(sede);
-	}
+        @PostMapping("/api/sede")
+        public Sede createSede(@RequestBody Sede sede){
+                return sedeService.create(sede);
+        }
+
+        @PutMapping("/api/sede")
+        public Sede updateSede(@RequestBody Sede sede){
+                return sedeService.create(sede);
+        }
 	
 	@DeleteMapping("/api/sede/{idSede}")
 	public void deleteSede(@PathVariable("idSede") Long id){

--- a/src/main/java/com/imb2025/calificaciones/controller/TipoNotaController.java
+++ b/src/main/java/com/imb2025/calificaciones/controller/TipoNotaController.java
@@ -46,7 +46,7 @@ public class TipoNotaController {
     // POST /tiponota - crear nuevo
     @PostMapping
     public TipoNota create(@RequestBody TipoNota tipoNota) {
-        return tipoNotaService.save(tipoNota);
+        return tipoNotaService.create(tipoNota);
     }
 
     // PUT /tiponota/{id} - actualizar existente
@@ -56,7 +56,7 @@ public class TipoNotaController {
             // Verificamos si el TipoNota existe antes de intentar actualizar
             tipoNotaService.findById(id);
 
-            TipoNota actualizado = tipoNotaService.update(id, tipoNota);
+            TipoNota actualizado = tipoNotaService.update(tipoNota, id);
             return ResponseEntity.ok(actualizado);
 
         } catch (RuntimeException e) {

--- a/src/main/java/com/imb2025/calificaciones/service/IAsistenciaService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IAsistenciaService.java
@@ -8,13 +8,13 @@ public interface IAsistenciaService {
 
     public List<Asistencia> findAll();
 
-    public Asistencia create(Asistencia asistencia);
+    public Asistencia create(AsistenciaRequestDto dto) throws Exception;
 
-    public Asistencia update(Asistencia asistencia, Long id);
+    public Asistencia update(AsistenciaRequestDto dto, Long id) throws Exception;
 
     public Asistencia findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public Asistencia fromDto(AsistenciaRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/ICursadaService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/ICursadaService.java
@@ -8,9 +8,9 @@ public interface ICursadaService {
 
     public List<Cursada> findAll();
 
-    public Cursada create(Cursada cursada);
+    public String create(CursadaRequestDto dto);
 
-    public Cursada update(Cursada cursada, Long id);
+    public String update(CursadaRequestDto dto, Long id);
 
     public Cursada findById(Long id);
 

--- a/src/main/java/com/imb2025/calificaciones/service/IRequisitoMateriaService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IRequisitoMateriaService.java
@@ -3,16 +3,17 @@ package com.imb2025.calificaciones.service;
 import com.imb2025.calificaciones.dto.RequisitoMateriaRequestDto;
 import com.imb2025.calificaciones.entity.RequisitoMateria;
 import java.util.List;
+import java.util.Optional;
 
 public interface IRequisitoMateriaService {
 
     public List<RequisitoMateria> findAll();
 
-    public RequisitoMateria create(RequisitoMateria requisitoMateria);
+    public RequisitoMateria create(RequisitoMateriaRequestDto dto);
 
-    public RequisitoMateria update(RequisitoMateria requisitoMateria, Long id);
+    public RequisitoMateria update(RequisitoMateriaRequestDto dto, Long id);
 
-    public RequisitoMateria findById(Long id);
+    public Optional<RequisitoMateria> findById(Long id);
 
     public void deleteById(Long id);
 

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/AsistenciaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/AsistenciaServiceImpl.java
@@ -37,7 +37,7 @@ public class AsistenciaServiceImpl implements IAsistenciaService {
     }
 
     @Override
-    public Asistencia save(AsistenciaRequestDto dto) throws Exception {
+    public Asistencia create(AsistenciaRequestDto dto) throws Exception {
         try {
             Asistencia asistencia = new Asistencia();
             if(dto.getAlumnoId() != null) {

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/CursadaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/CursadaServiceImpl.java
@@ -38,7 +38,7 @@ public class CursadaServiceImpl implements ICursadaService{
     }
 
     @Override
-    public String save(CursadaRequestDto dto) {
+    public String create(CursadaRequestDto dto) {
          Cursada cursada = new Cursada();
         Mapper(cursada, dto);
         return "Guardado correctamente";

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/EvaluacionServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/EvaluacionServiceImpl.java
@@ -42,7 +42,7 @@ public class EvaluacionServiceImpl implements IEvaluacionService {
 
     @Override
     @Transactional
-    public Evaluacion save(Evaluacion evaluacion) {
+    public Evaluacion create(Evaluacion evaluacion) {
         try {
             return evaluacionRepository.save(evaluacion);
 

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/NivelMateriaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/NivelMateriaServiceImpl.java
@@ -28,7 +28,7 @@ public class NivelMateriaServiceImpl implements INivelMateriaService {
     }
 
     @Override
-    public NivelMateria save(NivelMateria nivelMateria) {
+    public NivelMateria create(NivelMateria nivelMateria) {
          return repo.save(nivelMateria);
     }
 

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/PlanEstudioServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/PlanEstudioServiceImpl.java
@@ -39,7 +39,7 @@ public class PlanEstudioServiceImpl implements IPlanEstudioService {
 
     @Override
     @Transactional
-    public PlanEstudio save(PlanEstudio planEstudio) {
+    public PlanEstudio create(PlanEstudio planEstudio) {
         return planestudiorepository.save(planEstudio);
     }
 

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/RequisitoMateriaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/RequisitoMateriaServiceImpl.java
@@ -32,7 +32,7 @@ public class RequisitoMateriaServiceImpl implements IRequisitoMateriaService {
     }
 
     @Override
-    public RequisitoMateria save(RequisitoMateriaRequestDto dto) {
+    public RequisitoMateria create(RequisitoMateriaRequestDto dto) {
         try {
             RequisitoMateria requisito = fromDto(dto);
             return requisitoRepository.save(requisito);

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/SedeServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/SedeServiceImpl.java
@@ -34,7 +34,7 @@ public class SedeServiceImpl implements ISedeService {
     }
 
     @Override
-    public Sede save(Sede sede) {
+    public Sede create(Sede sede) {
         return repo.save(sede);
     }
 

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/TipoNotaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/TipoNotaServiceImpl.java
@@ -29,7 +29,7 @@ public class TipoNotaServiceImpl implements ITipoNotaService {
     }
 
     @Override
-    public TipoNota save(TipoNota tipoNota) {
+    public TipoNota create(TipoNota tipoNota) {
         try {
             return tipoNotaRepository.save(tipoNota);
         } catch (Exception e) {


### PR DESCRIPTION
## Summary
- rename various service layer `save` methods to `create`
- adjust controllers and interfaces to use `create`

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d106a070832fadc59d6a4378c490