### PR TITLE
Ensure delete operations verify entity existence

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/service/IAlumnoService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IAlumnoService.java
@@ -14,7 +14,7 @@ public interface IAlumnoService {
 
     public Alumno findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public Alumno fromDto(AlumnoRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IAsignacionDocenteService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IAsignacionDocenteService.java
@@ -14,7 +14,7 @@ public interface IAsignacionDocenteService {
 
     public AsignacionDocente findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public AsignacionDocente fromDto(AsignacionDocenteRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/ICalendarioMateriaService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/ICalendarioMateriaService.java
@@ -14,7 +14,7 @@ public interface ICalendarioMateriaService {
 
     public CalendarioMateria findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public CalendarioMateria fromDto(CalendarioMateriaRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/ICarreraService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/ICarreraService.java
@@ -14,7 +14,7 @@ public interface ICarreraService {
 
     public Carrera findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public Carrera fromDto(CarreraRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IComisionService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IComisionService.java
@@ -14,7 +14,7 @@ public interface IComisionService {
 
     public Comision findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public Comision fromDto(ComisionRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/ICondicionFinalService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/ICondicionFinalService.java
@@ -14,7 +14,7 @@ public interface ICondicionFinalService {
 
     public CondicionFinal findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public CondicionFinal fromDto(CondicionFinalRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/ICursadaService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/ICursadaService.java
@@ -14,7 +14,7 @@ public interface ICursadaService {
 
     public Cursada findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public Cursada fromDto(CursadaRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IDocenteService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IDocenteService.java
@@ -14,7 +14,7 @@ public interface IDocenteService {
 
     public Docente findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public Docente fromDto(DocenteRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IEstadoCursadaService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IEstadoCursadaService.java
@@ -14,7 +14,7 @@ public interface IEstadoCursadaService {
 
     public EstadoCursada findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public EstadoCursada fromDto(EstadoCursadaRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IEstadoEvaluacionService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IEstadoEvaluacionService.java
@@ -14,7 +14,7 @@ public interface IEstadoEvaluacionService {
 
     public EstadoEvaluacion findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public EstadoEvaluacion fromDto(EstadoEvaluacionRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IEvaluacionService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IEvaluacionService.java
@@ -14,7 +14,7 @@ public interface IEvaluacionService {
 
     public Evaluacion findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public Evaluacion fromDto(EvaluacionRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IHorarioService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IHorarioService.java
@@ -14,7 +14,7 @@ public interface IHorarioService {
 
     public Horario findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public Horario fromDto(HorarioRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IInscripcionMateriaService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IInscripcionMateriaService.java
@@ -14,7 +14,7 @@ public interface IInscripcionMateriaService {
 
     public InscripcionMateria findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public InscripcionMateria fromDto(InscripcionMateriaRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IMateriaService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IMateriaService.java
@@ -14,7 +14,7 @@ public interface IMateriaService {
 
     public Materia findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public Materia fromDto(MateriaRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/INivelMateriaService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/INivelMateriaService.java
@@ -14,7 +14,7 @@ public interface INivelMateriaService {
 
     public NivelMateria findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public NivelMateria fromDto(NivelMateriaRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IObservacionAlumnoService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IObservacionAlumnoService.java
@@ -14,7 +14,7 @@ public interface IObservacionAlumnoService {
 
     public ObservacionAlumno findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public ObservacionAlumno fromDto(ObservacionAlumnoRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IPeriodoLectivoService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IPeriodoLectivoService.java
@@ -14,7 +14,7 @@ public interface IPeriodoLectivoService {
 
     public PeriodoLectivo findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public PeriodoLectivo fromDto(PeriodoLectivoRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IPlanEstudioService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IPlanEstudioService.java
@@ -14,7 +14,7 @@ public interface IPlanEstudioService {
 
     public PlanEstudio findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public PlanEstudio fromDto(PlanEstudioRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IRegistroClaseService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IRegistroClaseService.java
@@ -14,7 +14,7 @@ public interface IRegistroClaseService {
 
     public RegistroClase findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public RegistroClase fromDto(RegistroClaseRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/IRequisitoMateriaService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IRequisitoMateriaService.java
@@ -15,7 +15,7 @@ public interface IRequisitoMateriaService {
 
     public Optional<RequisitoMateria> findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public RequisitoMateria fromDto(RequisitoMateriaRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/ISedeService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/ISedeService.java
@@ -14,7 +14,7 @@ public interface ISedeService {
 
     public Sede findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public Sede fromDto(SedeRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/ITipoEvaluacionService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/ITipoEvaluacionService.java
@@ -14,7 +14,7 @@ public interface ITipoEvaluacionService {
 
     public TipoEvaluacion findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public TipoEvaluacion fromDto(TipoEvaluacionRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/ITipoNotaService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/ITipoNotaService.java
@@ -14,7 +14,7 @@ public interface ITipoNotaService {
 
     public TipoNota findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public TipoNota fromDto(TipoNotaRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/ITurnoService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/ITurnoService.java
@@ -14,7 +14,7 @@ public interface ITurnoService {
 
     public Turno findById(Long id);
 
-    public void deleteById(Long id);
+    public void deleteById(Long id) throws Exception;
 
     public Turno fromDto(TurnoRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/AlumnoServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/AlumnoServiceImpl.java
@@ -40,12 +40,11 @@ public class AlumnoServiceImpl implements IAlumnoService {
     }
 
     @Override
-    public void deleteById(Long id) {
-        if (alumnoRepository.existsById(id)) {
-            alumnoRepository.deleteById(id);
-        } else {
-            throw new RuntimeException("Estudiante no encontrado");
+    public void deleteById(Long id) throws Exception {
+        if (!alumnoRepository.existsById(id)) {
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
         }
+        alumnoRepository.deleteById(id);
     }
 
     @Override

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/AsignacionDocenteServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/AsignacionDocenteServiceImpl.java
@@ -62,8 +62,7 @@ public class AsignacionDocenteServiceImpl implements IAsignacionDocenteService {
     @Override
     public void deleteById(Long id) throws Exception {
         if (!repository.existsById(id)) {
-            throw new Exception(
-                    "Can't delete AsignacionDocente with id: " + id + " because it does not exist");
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
         }
         repository.deleteById(id);
     }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/AsistenciaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/AsistenciaServiceImpl.java
@@ -107,14 +107,9 @@ public class AsistenciaServiceImpl implements IAsistenciaService {
     @Override
     public void deleteById(Long id) throws Exception {
         if (!asistenciaRepository.existsById(id)) {
-            throw new Exception("No se encontró la asistencia con ID: " + id);
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
         }
-
-        try {
-            asistenciaRepository.deleteById(id);
-        } catch (Exception e) {
-            throw new Exception("Error al eliminar la asistencia: " + e.getMessage());
-        }
+        asistenciaRepository.deleteById(id);
     }
 
     @Override

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/CalendarioMateriaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/CalendarioMateriaServiceImpl.java
@@ -52,10 +52,11 @@ public class CalendarioMateriaServiceImpl implements ICalendarioMateriaService {
 
     @Override
     @Transactional
-    public void deleteById(Long id) {
-        if (calMatRepo.existsById(id)) {
-            calMatRepo.deleteById(id);
+    public void deleteById(Long id) throws Exception {
+        if (!calMatRepo.existsById(id)) {
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
         }
+        calMatRepo.deleteById(id);
     }
 
     @Override

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/CarreraServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/CarreraServiceImpl.java
@@ -45,10 +45,11 @@ public class CarreraServiceImpl implements ICarreraService {
     }
 
     @Override
-    public void deleteById(Long id) {
-
+    public void deleteById(Long id) throws Exception {
+        if (!repo.existsById(id)) {
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
+        }
         repo.deleteById(id);
-
     }
 
     @Override

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/ComisionServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/ComisionServiceImpl.java
@@ -50,7 +50,10 @@ public class ComisionServiceImpl implements IComisionService {
     }
 
     @Override
-    public void deleteById(Long id) {
+    public void deleteById(Long id) throws Exception {
+        if (!repository.existsById(id)) {
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
+        }
         repository.deleteById(id);
     }
 

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/CondicionFinalServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/CondicionFinalServiceImpl.java
@@ -39,7 +39,10 @@ public class CondicionFinalServiceImpl implements ICondicionFinalService {
     }
 
     @Override
-    public void deleteById(Long id) {
+    public void deleteById(Long id) throws Exception {
+        if (!repository.existsById(id)) {
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
+        }
         repository.deleteById(id);
     }
 

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/CursadaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/CursadaServiceImpl.java
@@ -45,7 +45,10 @@ public class CursadaServiceImpl implements ICursadaService{
     }
 
     @Override
-    public void deleteById(Long id) {
+    public void deleteById(Long id) throws Exception {
+        if (!repo.existsById(id)) {
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
+        }
         repo.deleteById(id);
     }
 

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/DocenteServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/DocenteServiceImpl.java
@@ -63,10 +63,11 @@ public class DocenteServiceImpl implements IDocenteService {
     }
 
     @Override
-    public void deleteById(Long id) {
-
-            repo.deleteById(id);
-
+    public void deleteById(Long id) throws Exception {
+        if (!repo.existsById(id)) {
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
+        }
+        repo.deleteById(id);
     }
 
 }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/EstadoCursadaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/EstadoCursadaServiceImpl.java
@@ -43,7 +43,10 @@ public class EstadoCursadaServiceImpl implements IEstadoCursadaService {
     }
 
     @Override
-    public void deleteById(Long id) {
+    public void deleteById(Long id) throws Exception {
+        if (!repository.existsById(id)) {
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
+        }
         repository.deleteById(id);
     }
 

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/EstadoEvaluacionServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/EstadoEvaluacionServiceImpl.java
@@ -50,7 +50,10 @@ public class EstadoEvaluacionServiceImpl implements IEstadoEvaluacionService {
     }
 
     @Override
-    public void deleteById(Long id) {
+    public void deleteById(Long id) throws Exception {
+        if (!repository.existsById(id)) {
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
+        }
         repository.deleteById(id);
     }
 

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/EvaluacionServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/EvaluacionServiceImpl.java
@@ -111,7 +111,10 @@ public class EvaluacionServiceImpl implements IEvaluacionService {
     }
 
     @Override
-    public void deleteById(Long id) {
+    public void deleteById(Long id) throws Exception {
+        if (!evaluacionRepository.existsById(id)) {
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
+        }
         evaluacionRepository.deleteById(id);
     }
 

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/HorarioServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/HorarioServiceImpl.java
@@ -39,7 +39,10 @@ public class HorarioServiceImpl implements IHorarioService{
     }
 
     @Override
-    public void deleteById(Long id) {
+    public void deleteById(Long id) throws Exception {
+        if (!horarioRepository.existsById(id)) {
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
+        }
         horarioRepository.deleteById(id);
     }
 

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/InscripcionMateriaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/InscripcionMateriaServiceImpl.java
@@ -53,7 +53,11 @@ public class InscripcionMateriaServiceImpl implements IInscripcionMateriaService
 
     }
 
-    public void deleteById(Long id) {
+    @Override
+    public void deleteById(Long id) throws Exception {
+        if (!repository.existsById(id)) {
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
+        }
         repository.deleteById(id);
     }
 

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/MateriaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/MateriaServiceImpl.java
@@ -46,9 +46,11 @@ public class MateriaServiceImpl implements IMateriaService{
     }
 
     @Override
-    public void deleteById(long id) {
+    public void deleteById(Long id) throws Exception {
+        if (!repo.existsById(id)) {
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
+        }
         repo.deleteById(id);
-
     }
 
     @Override

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/NivelMateriaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/NivelMateriaServiceImpl.java
@@ -33,9 +33,11 @@ public class NivelMateriaServiceImpl implements INivelMateriaService {
     }
 
     @Override
-    public void deleteById(Long id) {
+    public void deleteById(Long id) throws Exception {
+        if (!repo.existsById(id)) {
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
+        }
         repo.deleteById(id);
-
     }
 
     @Override

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/ObservacionAlumnoServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/ObservacionAlumnoServiceImpl.java
@@ -63,18 +63,11 @@ public class ObservacionAlumnoServiceImpl implements IObservacionAlumnoService{
     }
 
     @Override
-    public void deleteById(Long id) throws Exception{
-        try {
-            Optional<ObservacionAlumno> obs = observacionAlumnoRepository.findById(id);
-            if (obs.isPresent()) {
-                observacionAlumnoRepository.deleteById(id);
-            } else {
-                throw new Exception("la observación de alumno no existe");
-            }
-        } catch (Exception e) {
-            throw new RuntimeException("error al eliminar la observación del alumno: " + e.getMessage());
+    public void deleteById(Long id) throws Exception {
+        if (!observacionAlumnoRepository.existsById(id)) {
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
         }
-
+        observacionAlumnoRepository.deleteById(id);
     }
 
     @Override

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/PeriodoLectivoServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/PeriodoLectivoServiceImpl.java
@@ -42,9 +42,9 @@ public class PeriodoLectivoServiceImpl implements IPeriodoLectivoService{
 
     @Override
     public void deleteById(Long id) throws Exception {
-        repository.findById(id).orElseThrow(
-                () -> new Exception("Periodo no encontrado")
-        );
+        if (!repository.existsById(id)) {
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
+        }
         repository.deleteById(id);
     }
 

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/PlanEstudioServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/PlanEstudioServiceImpl.java
@@ -65,7 +65,10 @@ public class PlanEstudioServiceImpl implements IPlanEstudioService {
 
     @Override
     @Transactional
-    public void deleteById(Long id) {
+    public void deleteById(Long id) throws Exception {
+        if (!planestudiorepository.existsById(id)) {
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
+        }
         planestudiorepository.deleteById(id);
     }
 

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/RegistroClaseServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/RegistroClaseServiceImpl.java
@@ -46,9 +46,9 @@ public class RegistroClaseServiceImpl implements IRegistroClaseService {
     }
 
     @Override
-    public void deleteById(Long id) {
+    public void deleteById(Long id) throws Exception {
         if (!registroClaseRepository.existsById(id)) {
-            throw new EntidadNoEncontradaException("RegistroClase no encontrado con ID: " + id);
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
         }
         registroClaseRepository.deleteById(id);
     }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/RequisitoMateriaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/RequisitoMateriaServiceImpl.java
@@ -60,7 +60,10 @@ public class RequisitoMateriaServiceImpl implements IRequisitoMateriaService {
     }
 
     @Override
-    public void deleteById(Long id) {
+    public void deleteById(Long id) throws Exception {
+        if (!requisitoRepository.existsById(id)) {
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
+        }
         requisitoRepository.deleteById(id);
     }
 

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/SedeServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/SedeServiceImpl.java
@@ -49,7 +49,10 @@ public class SedeServiceImpl implements ISedeService {
     }
 
     @Override
-    public void deleteById(Long id) {
+    public void deleteById(Long id) throws Exception {
+        if (!repo.existsById(id)) {
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
+        }
         repo.deleteById(id);
     }
 

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/TipoEvaluacionServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/TipoEvaluacionServiceImpl.java
@@ -43,9 +43,9 @@ public class TipoEvaluacionServiceImpl implements ITipoEvaluacionService {
     }
 
     @Override
-    public void deleteById(Long id) {
+    public void deleteById(Long id) throws Exception {
         if (!repo.existsById(id)) {
-            throw new RuntimeException("No existe el tipo de evaluación con ID " + id);
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
         }
         repo.deleteById(id);
     }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/TipoNotaServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/TipoNotaServiceImpl.java
@@ -47,7 +47,10 @@ public class TipoNotaServiceImpl implements ITipoNotaService {
     }
 
     @Override
-    public void deleteById(Long id) {
+    public void deleteById(Long id) throws Exception {
+        if (!tipoNotaRepository.existsById(id)) {
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
+        }
         tipoNotaRepository.deleteById(id);
     }
 

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/TurnoServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/TurnoServiceImpl.java
@@ -42,12 +42,11 @@ public class TurnoServiceImpl implements ITurnoService {
     }
 
     @Override
-    public void deleteById(Long id) throws Exception  {
-        if (turnoRepository.existsById(id)) {
-            turnoRepository.deleteById(id);
-        } else {
-            throw new Exception("Turno no encontrado");
+    public void deleteById(Long id) throws Exception {
+        if (!turnoRepository.existsById(id)) {
+            throw new Exception("No se puede eliminar el id: " + id + " porque no existe");
         }
+        turnoRepository.deleteById(id);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Add existence checks and exception messages to `deleteById` across all JPA services
- Declare `throws Exception` on `deleteById` in corresponding service interfaces

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1eea7c078832f87bbe39c0ef3beb5