### PR TITLE
TP 05 - Alejo Quevedo - Validaciones JSR-380 en PeriodoLectivoDTO

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/controller/PeriodoLectivoController.java
+++ b/src/main/java/com/imb2025/calificaciones/controller/PeriodoLectivoController.java
@@ -22,6 +22,8 @@ import com.imb2025.calificaciones.dto.PeriodoLectivoRequestDto;
 import com.imb2025.calificaciones.entity.PeriodoLectivo;
 import com.imb2025.calificaciones.service.IPeriodoLectivoService;
 
+import jakarta.validation.Valid;
+
 @RestController
 @RequestMapping("/api/periodo-lectivo")
 public class PeriodoLectivoController {
@@ -43,7 +45,8 @@ public class PeriodoLectivoController {
         }
 
         @PostMapping
-        public ResponseEntity<ApiResponseSuccessDto<PeriodoLectivo>> create(@RequestBody PeriodoLectivoRequestDto periodoLectivo) throws Exception {
+        public ResponseEntity<ApiResponseSuccessDto<PeriodoLectivo>> create(
+        		@Valid @RequestBody PeriodoLectivoRequestDto periodoLectivo) throws Exception {
                 PeriodoLectivo createdPeriodoLectivo = service.create(
                                         service.fromDto(periodoLectivo)
                                 );
@@ -53,7 +56,7 @@ public class PeriodoLectivoController {
 
         @PutMapping("/{id}")
         public ResponseEntity<ApiResponseSuccessDto<PeriodoLectivo>> updateById(@PathVariable Long id,
-                        @RequestBody PeriodoLectivoRequestDto periodoLectivo) throws Exception {
+                        @Valid @RequestBody PeriodoLectivoRequestDto periodoLectivo) throws Exception {
                 PeriodoLectivo updatedPeriodoLectivo = service.update(
                                 service.fromDto(periodoLectivo),
                                 id

--- a/src/main/java/com/imb2025/calificaciones/dto/PeriodoLectivoRequestDto.java
+++ b/src/main/java/com/imb2025/calificaciones/dto/PeriodoLectivoRequestDto.java
@@ -2,10 +2,19 @@ package com.imb2025.calificaciones.dto;
 
 import java.time.LocalDate;
 
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PastOrPresent;
+
 public class PeriodoLectivoRequestDto {
 
+	@NotBlank(message = "El nombre no puede estar vacio.")
     private String nombre;
+	
+	@PastOrPresent(message = "La fecha debe ser pasada o actual.")
     private LocalDate fechaInicio;
+	
+	@FutureOrPresent(message = "La fecha debe ser futura o actual.")
     private LocalDate fechaFin;
 
     public PeriodoLectivoRequestDto() {


### PR DESCRIPTION
- Se modifico la clase `PeriodoLectivoRequestDto` añadiendo las siguientes anotaciones a sus atributos para aplicar las validaciones estándar (JSR-380) sobre el mismo:
    - `NotBlank` para comprobar de que `nombre` no este vació.
    - `PastOrPresent` para comprobar de que `fechaInicio` no tenga una fecha del futuro.
    - `FutureOrPresent` para comprobar de que `fechaFin` no tenga una fecha del pasado.
- Se modificaron las funciones `create` y `updateById` de `PeriodoLectivoController` añadiendo solamente la anotación `Valid` para comprobar de que el cuerpo de `PeriodoLectivoRequestDto` cumpla con las restricciones antes mencionadas.