### PR TITLE
Add CRUD support for ObraSocial

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/controller/ObraSocialController.java
+++ b/src/main/java/com/imb2025/calificaciones/controller/ObraSocialController.java
@@ -1,0 +1,96 @@
+package com.imb2025.calificaciones.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.imb2025.calificaciones.dto.ApiResponseSuccessDto;
+import com.imb2025.calificaciones.dto.ObraSocialRequestDto;
+import com.imb2025.calificaciones.entity.ObraSocial;
+import com.imb2025.calificaciones.service.IObraSocialService;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/obras-sociales")
+public class ObraSocialController {
+
+    @Autowired
+    private IObraSocialService obraSocialService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponseSuccessDto<List<ObraSocial>>> getAll() {
+        List<ObraSocial> obrasSociales = obraSocialService.findAll();
+
+        ApiResponseSuccessDto<List<ObraSocial>> response = new ApiResponseSuccessDto<>();
+        response.setSuccess(true);
+        response.setMessage("Obras sociales obtenidas con éxito");
+        response.setData(obrasSociales);
+
+        return obrasSociales.isEmpty()
+                ? ResponseEntity.noContent().build()
+                : ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponseSuccessDto<ObraSocial>> getById(@PathVariable Long id) {
+        ObraSocial obraSocial = obraSocialService.findById(id);
+
+        ApiResponseSuccessDto<ObraSocial> response = new ApiResponseSuccessDto<>();
+        response.setSuccess(true);
+        response.setMessage("Obra social encontrada con éxito");
+        response.setData(obraSocial);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponseSuccessDto<ObraSocial>> create(@Valid @RequestBody ObraSocialRequestDto dto) {
+        ObraSocial obraSocial = obraSocialService.fromDto(dto);
+        obraSocial = obraSocialService.create(obraSocial);
+
+        ApiResponseSuccessDto<ObraSocial> response = new ApiResponseSuccessDto<>();
+        response.setSuccess(true);
+        response.setMessage("Obra social creada con éxito");
+        response.setData(obraSocial);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponseSuccessDto<ObraSocial>> update(@PathVariable Long id,
+            @Valid @RequestBody ObraSocialRequestDto dto) throws Exception {
+
+        ObraSocial obraSocial = obraSocialService.fromDto(dto);
+        obraSocial = obraSocialService.update(obraSocial, id);
+
+        ApiResponseSuccessDto<ObraSocial> response = new ApiResponseSuccessDto<>();
+        response.setSuccess(true);
+        response.setMessage("Obra social actualizada con éxito");
+        response.setData(obraSocial);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponseSuccessDto<Void>> delete(@PathVariable Long id) {
+        obraSocialService.deleteById(id);
+
+        ApiResponseSuccessDto<Void> response = new ApiResponseSuccessDto<>();
+        response.setSuccess(true);
+        response.setMessage("Obra social eliminada con éxito");
+        response.setData(null);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/imb2025/calificaciones/dto/ObraSocialRequestDto.java
+++ b/src/main/java/com/imb2025/calificaciones/dto/ObraSocialRequestDto.java
@@ -1,0 +1,52 @@
+package com.imb2025.calificaciones.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public class ObraSocialRequestDto {
+
+    @NotBlank(message = "El nombre de la obra social es obligatorio")
+    @Size(max = 100, message = "El nombre no puede superar los 100 caracteres")
+    private String nombre;
+
+    @Size(max = 255, message = "La descripción no puede superar los 255 caracteres")
+    private String descripcion;
+
+    @Size(max = 30, message = "El teléfono no puede superar los 30 caracteres")
+    @Pattern(regexp = "^[0-9+\\-\\s]*$", message = "El teléfono solo puede contener números, espacios y los símbolos + o -")
+    private String telefonoContacto;
+
+    public ObraSocialRequestDto() {
+    }
+
+    public ObraSocialRequestDto(String nombre, String descripcion, String telefonoContacto) {
+        this.nombre = nombre;
+        this.descripcion = descripcion;
+        this.telefonoContacto = telefonoContacto;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getDescripcion() {
+        return descripcion;
+    }
+
+    public void setDescripcion(String descripcion) {
+        this.descripcion = descripcion;
+    }
+
+    public String getTelefonoContacto() {
+        return telefonoContacto;
+    }
+
+    public void setTelefonoContacto(String telefonoContacto) {
+        this.telefonoContacto = telefonoContacto;
+    }
+}

--- a/src/main/java/com/imb2025/calificaciones/entity/ObraSocial.java
+++ b/src/main/java/com/imb2025/calificaciones/entity/ObraSocial.java
@@ -1,0 +1,72 @@
+package com.imb2025.calificaciones.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class ObraSocial {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String nombre;
+
+    @Column(length = 255)
+    private String descripcion;
+
+    @Column(name = "telefono_contacto", length = 30)
+    private String telefonoContacto;
+
+    public ObraSocial() {
+    }
+
+    public ObraSocial(Long id, String nombre, String descripcion, String telefonoContacto) {
+        this.id = id;
+        this.nombre = nombre;
+        this.descripcion = descripcion;
+        this.telefonoContacto = telefonoContacto;
+    }
+
+    public ObraSocial(String nombre, String descripcion, String telefonoContacto) {
+        this.nombre = nombre;
+        this.descripcion = descripcion;
+        this.telefonoContacto = telefonoContacto;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getDescripcion() {
+        return descripcion;
+    }
+
+    public void setDescripcion(String descripcion) {
+        this.descripcion = descripcion;
+    }
+
+    public String getTelefonoContacto() {
+        return telefonoContacto;
+    }
+
+    public void setTelefonoContacto(String telefonoContacto) {
+        this.telefonoContacto = telefonoContacto;
+    }
+}

--- a/src/main/java/com/imb2025/calificaciones/repository/ObraSocialRepository.java
+++ b/src/main/java/com/imb2025/calificaciones/repository/ObraSocialRepository.java
@@ -1,0 +1,10 @@
+package com.imb2025.calificaciones.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.imb2025.calificaciones.entity.ObraSocial;
+
+@Repository
+public interface ObraSocialRepository extends JpaRepository<ObraSocial, Long> {
+}

--- a/src/main/java/com/imb2025/calificaciones/service/IObraSocialService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IObraSocialService.java
@@ -1,0 +1,22 @@
+package com.imb2025.calificaciones.service;
+
+import java.util.List;
+
+import com.imb2025.calificaciones.dto.ObraSocialRequestDto;
+import com.imb2025.calificaciones.entity.ObraSocial;
+import com.imb2025.calificaciones.exception.ResourceNotFoundException;
+
+public interface IObraSocialService {
+
+    List<ObraSocial> findAll();
+
+    ObraSocial create(ObraSocial obraSocial);
+
+    ObraSocial update(ObraSocial obraSocial, Long id) throws ResourceNotFoundException, Exception;
+
+    ObraSocial findById(Long id) throws ResourceNotFoundException;
+
+    void deleteById(Long id) throws ResourceNotFoundException;
+
+    ObraSocial fromDto(ObraSocialRequestDto dto);
+}

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/ObraSocialServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/ObraSocialServiceImpl.java
@@ -1,0 +1,77 @@
+package com.imb2025.calificaciones.service.jpa;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.imb2025.calificaciones.dto.ObraSocialRequestDto;
+import com.imb2025.calificaciones.entity.ObraSocial;
+import com.imb2025.calificaciones.exception.ResourceNotFoundException;
+import com.imb2025.calificaciones.repository.ObraSocialRepository;
+import com.imb2025.calificaciones.service.IObraSocialService;
+
+import jakarta.transaction.Transactional;
+
+@Service
+public class ObraSocialServiceImpl implements IObraSocialService {
+
+    @Autowired
+    private ObraSocialRepository obraSocialRepository;
+
+    @Override
+    public List<ObraSocial> findAll() {
+        return obraSocialRepository.findAll();
+    }
+
+    @Override
+    public ObraSocial findById(Long id) {
+        return obraSocialRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Obra social con id " + id + " no encontrada"));
+    }
+
+    @Override
+    @Transactional
+    public ObraSocial create(ObraSocial obraSocial) {
+        return obraSocialRepository.save(obraSocial);
+    }
+
+    @Override
+    @Transactional
+    public ObraSocial update(ObraSocial obraSocial, Long id) throws Exception {
+        if (id == null) {
+            throw new Exception("No se pudo identificar el id");
+        }
+
+        ObraSocial existente = obraSocialRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Obra social con id " + id + " no encontrada"));
+
+        existente.setNombre(obraSocial.getNombre());
+        existente.setDescripcion(obraSocial.getDescripcion());
+        existente.setTelefonoContacto(obraSocial.getTelefonoContacto());
+
+        return obraSocialRepository.save(existente);
+    }
+
+    @Override
+    @Transactional
+    public void deleteById(Long id) {
+        if (!obraSocialRepository.existsById(id)) {
+            throw new ResourceNotFoundException("No se puede eliminar el id: " + id + " porque no existe");
+        }
+        obraSocialRepository.deleteById(id);
+    }
+
+    @Override
+    public ObraSocial fromDto(ObraSocialRequestDto dto) {
+        if (dto == null) {
+            throw new IllegalArgumentException("El DTO de obra social no puede ser nulo");
+        }
+
+        ObraSocial obraSocial = new ObraSocial();
+        obraSocial.setNombre(dto.getNombre());
+        obraSocial.setDescripcion(dto.getDescripcion());
+        obraSocial.setTelefonoContacto(dto.getTelefonoContacto());
+        return obraSocial;
+    }
+}


### PR DESCRIPTION
## Summary
- add ObraSocial entity, DTO, repository, and service layer to represent obras sociales
- expose CRUD endpoints for obras sociales with validated request payloads and consistent API responses

## Testing
- ./mvnw -q test *(fails: unable to download Maven distribution in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4591755c832f9cba7866d83a60d3