### PR TITLE
TP08 - Alejo Quevedo - Refactor de DTOs y Mapper

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/controller/PeriodoLectivoController.java
+++ b/src/main/java/com/imb2025/calificaciones/controller/PeriodoLectivoController.java
@@ -21,7 +21,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import com.imb2025.calificaciones.dto.ApiResponseSuccessDto;
-import com.imb2025.calificaciones.dto.PeriodoLectivoRequestDto;
+import com.imb2025.calificaciones.dto.mapper.PeriodoLectivoMapper;
+import com.imb2025.calificaciones.dto.request.PeriodoLectivoRequestDto;
+import com.imb2025.calificaciones.dto.response.PeriodoLectivoResponseDto;
 import com.imb2025.calificaciones.entity.PeriodoLectivo;
 import com.imb2025.calificaciones.service.IPeriodoLectivoService;
 
@@ -34,26 +36,36 @@ public class PeriodoLectivoController {
 	@Autowired
 	private IPeriodoLectivoService service;
 	
+	@Autowired
+	private PeriodoLectivoMapper mapper;
+	
 	@GetMapping
-    public ResponseEntity<ApiResponseSuccessDto<List<PeriodoLectivo>>> getAll() {
-		List<PeriodoLectivo> periodos = service.findAll();
-        ApiResponseSuccessDto<List<PeriodoLectivo>> response = 
-        		new ApiResponseSuccessDto<List<PeriodoLectivo>>(true, "Periodos Lectivos encontrados con éxito", periodos);
+    public ResponseEntity<ApiResponseSuccessDto<List<PeriodoLectivoResponseDto>>> getAll() {
+		List<PeriodoLectivo> resultados = service.findAll();
+		
+		List<PeriodoLectivoResponseDto> periodos = resultados.stream().map(p -> mapper.toResponse(p)).toList();
+		
+        ApiResponseSuccessDto<List<PeriodoLectivoResponseDto>> response = 
+        		new ApiResponseSuccessDto<List<PeriodoLectivoResponseDto>>(true, "Periodos Lectivos encontrados con éxito", periodos);
         return periodos.isEmpty() ? ResponseEntity.noContent().build() : ResponseEntity.ok(response);
     }
 
 	@GetMapping("/{id}")
-	public ResponseEntity<ApiResponseSuccessDto<PeriodoLectivo>> getById(@PathVariable Long id) {
-		PeriodoLectivo periodoLectivo = service.findById(id);
-		ApiResponseSuccessDto<PeriodoLectivo> response = new ApiResponseSuccessDto<PeriodoLectivo>(true, "Periodo Lectivo encontrado con éxito", periodoLectivo); 
+	public ResponseEntity<ApiResponseSuccessDto<PeriodoLectivoResponseDto>> getById(@PathVariable Long id) {
+		PeriodoLectivo resultado = service.findById(id);
+		PeriodoLectivoResponseDto periodoLectivo = mapper.toResponse(resultado);
+		ApiResponseSuccessDto<PeriodoLectivoResponseDto> response = new ApiResponseSuccessDto<PeriodoLectivoResponseDto>(true, "Periodo Lectivo encontrado con éxito", periodoLectivo); 
 		return ResponseEntity.ok(response);
 	}
         
 	@GetMapping("/get")
-	public ResponseEntity<ApiResponseSuccessDto<List<PeriodoLectivo>>> getByNombre(
+	public ResponseEntity<ApiResponseSuccessDto<List<PeriodoLectivoResponseDto>>> getByNombre(
 			@RequestParam(required = true) String nombre) {
-        List<PeriodoLectivo> periodos = service.findAllByNombre(nombre);
- 		ApiResponseSuccessDto<List<PeriodoLectivo>> response = new ApiResponseSuccessDto<List<PeriodoLectivo>>(true, "Periodos Lectivos con el nombre "+ nombre +" encontrados con éxito", periodos);
+        List<PeriodoLectivo> resultados = service.findAllByNombre(nombre);
+        
+		List<PeriodoLectivoResponseDto> periodos = resultados.stream().map(p -> mapper.toResponse(p)).toList();
+        
+ 		ApiResponseSuccessDto<List<PeriodoLectivoResponseDto>> response = new ApiResponseSuccessDto<List<PeriodoLectivoResponseDto>>(true, "Periodos Lectivos con el nombre "+ nombre +" encontrados con éxito", periodos);
         return periodos.isEmpty() ? ResponseEntity.noContent().build() : ResponseEntity.ok(response);
     }
     
@@ -69,23 +81,25 @@ public class PeriodoLectivoController {
     }
 
     @PostMapping
-    public ResponseEntity<ApiResponseSuccessDto<PeriodoLectivo>> create(
+    public ResponseEntity<ApiResponseSuccessDto<PeriodoLectivoResponseDto>> create(
         @Valid @RequestBody PeriodoLectivoRequestDto periodoLectivo) throws Exception {
-    	PeriodoLectivo createdPeriodoLectivo = service.create(
-    			service.fromDto(periodoLectivo)
+    	PeriodoLectivo resultado = service.create(
+    			mapper.fromDto(periodoLectivo)
     			);
-    	ApiResponseSuccessDto<PeriodoLectivo> response = new ApiResponseSuccessDto<PeriodoLectivo>(true, "Periodo Lectivo creado con éxito", createdPeriodoLectivo);
+    	PeriodoLectivoResponseDto createdPeriodoLectivo = mapper.toResponse(resultado);
+    	ApiResponseSuccessDto<PeriodoLectivoResponseDto> response = new ApiResponseSuccessDto<PeriodoLectivoResponseDto>(true, "Periodo Lectivo creado con éxito", createdPeriodoLectivo);
     	return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<ApiResponseSuccessDto<PeriodoLectivo>> updateById(@PathVariable Long id,
+    public ResponseEntity<ApiResponseSuccessDto<PeriodoLectivoResponseDto>> updateById(@PathVariable Long id,
     	@Valid @RequestBody PeriodoLectivoRequestDto periodoLectivo) throws Exception {
-    	PeriodoLectivo updatedPeriodoLectivo = service.update(
-    			service.fromDto(periodoLectivo),
+    	PeriodoLectivo resultado = service.update(
+    			mapper.fromDto(periodoLectivo),
     			id
     			);
-    	ApiResponseSuccessDto<PeriodoLectivo> response = new ApiResponseSuccessDto<PeriodoLectivo>(true, "Periodo Lectivo actualizado con éxito", updatedPeriodoLectivo);
+    	PeriodoLectivoResponseDto updatedPeriodoLectivo = mapper.toResponse(resultado);
+    	ApiResponseSuccessDto<PeriodoLectivoResponseDto> response = new ApiResponseSuccessDto<PeriodoLectivoResponseDto>(true, "Periodo Lectivo actualizado con éxito", updatedPeriodoLectivo);
     	return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 

--- a/src/main/java/com/imb2025/calificaciones/dto/mapper/PeriodoLectivoMapper.java
+++ b/src/main/java/com/imb2025/calificaciones/dto/mapper/PeriodoLectivoMapper.java
@@ -1,0 +1,33 @@
+package com.imb2025.calificaciones.dto.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.imb2025.calificaciones.dto.request.PeriodoLectivoRequestDto;
+import com.imb2025.calificaciones.dto.response.PeriodoLectivoResponseDto;
+import com.imb2025.calificaciones.entity.PeriodoLectivo;
+
+@Component
+public class PeriodoLectivoMapper {
+	
+	public PeriodoLectivo fromDto(PeriodoLectivoRequestDto requestDTO) {
+        PeriodoLectivo periodoLectivo = new PeriodoLectivo();
+
+        periodoLectivo.setNombre(requestDTO.getNombre());
+        periodoLectivo.setFechaInicio(requestDTO.getFechaInicio());
+        periodoLectivo.setFechaFin(requestDTO.getFechaFin());
+
+        return periodoLectivo;
+    }
+	
+	public PeriodoLectivoResponseDto toResponse(PeriodoLectivo periodo) {
+		PeriodoLectivoResponseDto dto = new PeriodoLectivoResponseDto();
+		
+		dto.setId(periodo.getId());
+		dto.setNombre(periodo.getNombre());
+		dto.setFechaInicio(periodo.getFechaInicio());
+		dto.setFechaFin(periodo.getFechaFin());
+		dto.setVersion(periodo.getVersion());
+		
+		return dto;
+	}
+}

--- a/src/main/java/com/imb2025/calificaciones/dto/request/PeriodoLectivoRequestDto.java
+++ b/src/main/java/com/imb2025/calificaciones/dto/request/PeriodoLectivoRequestDto.java
@@ -1,4 +1,4 @@
-package com.imb2025.calificaciones.dto;
+package com.imb2025.calificaciones.dto.request;
 
 import java.time.LocalDate;
 

--- a/src/main/java/com/imb2025/calificaciones/dto/response/PeriodoLectivoResponseDto.java
+++ b/src/main/java/com/imb2025/calificaciones/dto/response/PeriodoLectivoResponseDto.java
@@ -1,0 +1,63 @@
+package com.imb2025.calificaciones.dto.response;
+
+import java.time.LocalDate;
+
+public class PeriodoLectivoResponseDto {
+	private Long id;
+	private String nombre;
+	private LocalDate fechaInicio;
+	private LocalDate fechaFin;
+    private Long version;
+    
+    public PeriodoLectivoResponseDto() {
+    }
+    
+	public PeriodoLectivoResponseDto(Long id, String nombre, LocalDate fechaInicio, LocalDate fechaFin, Long version) {
+		this.id = id;
+		this.nombre = nombre;
+		this.fechaInicio = fechaInicio;
+		this.fechaFin = fechaFin;
+		this.version = version;
+	}
+	
+	public Long getId() {
+		return id;
+	}
+	
+	public void setId(Long id) {
+		this.id = id;
+	}
+	
+	public String getNombre() {
+		return nombre;
+	}
+	
+	public void setNombre(String nombre) {
+		this.nombre = nombre;
+	}
+	
+	public LocalDate getFechaInicio() {
+		return fechaInicio;
+	}
+	
+	public void setFechaInicio(LocalDate fechaInicio) {
+		this.fechaInicio = fechaInicio;
+	}
+	
+	public LocalDate getFechaFin() {
+		return fechaFin;
+	}
+	
+	public void setFechaFin(LocalDate fechaFin) {
+		this.fechaFin = fechaFin;
+	}
+	
+	public Long getVersion() {
+		return version;
+	}
+	
+	public void setVersion(Long version) {
+		this.version = version;
+	}
+    
+}

--- a/src/main/java/com/imb2025/calificaciones/entity/PeriodoLectivo.java
+++ b/src/main/java/com/imb2025/calificaciones/entity/PeriodoLectivo.java
@@ -3,16 +3,9 @@ package com.imb2025.calificaciones.entity;
 import java.time.LocalDate;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 
 @Entity
-public class PeriodoLectivo {
-	
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+public class PeriodoLectivo extends BaseEntity {
 	private String nombre;
 	private LocalDate fechaInicio;
 	private LocalDate fechaFin;
@@ -23,21 +16,6 @@ public class PeriodoLectivo {
 		this.nombre = nombre;
 		this.fechaInicio = fechaInicio;
 		this.fechaFin = fechaFin;
-	}
-
-	public PeriodoLectivo(Long id, String nombre, LocalDate fechaInicio, LocalDate fechaFin) {
-		this.id = id;
-		this.nombre = nombre;
-		this.fechaInicio = fechaInicio;
-		this.fechaFin = fechaFin;
-	}
-
-	public Long getId() {
-		return id;
-	}
-
-	public void setId(Long id) {
-		this.id = id;
 	}
 
 	public String getNombre() {

--- a/src/main/java/com/imb2025/calificaciones/service/IPeriodoLectivoService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IPeriodoLectivoService.java
@@ -1,6 +1,5 @@
 package com.imb2025.calificaciones.service;
 
-import com.imb2025.calificaciones.dto.PeriodoLectivoRequestDto;
 import com.imb2025.calificaciones.entity.PeriodoLectivo;
 
 import java.time.LocalDate;
@@ -21,6 +20,4 @@ public interface IPeriodoLectivoService {
     public PeriodoLectivo findById(Long id);
 
     public void deleteById(Long id) throws Exception;
-
-    public PeriodoLectivo fromDto(PeriodoLectivoRequestDto dto) throws Exception;
 }

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/PeriodoLectivoServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/PeriodoLectivoServiceImpl.java
@@ -6,7 +6,6 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.imb2025.calificaciones.dto.PeriodoLectivoRequestDto;
 import com.imb2025.calificaciones.entity.PeriodoLectivo;
 import com.imb2025.calificaciones.exception.ResourceNotFoundException;
 import com.imb2025.calificaciones.repository.PeriodoLectivoRepository;
@@ -54,17 +53,6 @@ public class PeriodoLectivoServiceImpl implements IPeriodoLectivoService{
             throw new ResourceNotFoundException("Entidad no encontrada con id " + id);
         }
         repository.deleteById(id);
-    }
-
-    @Override
-    public PeriodoLectivo fromDto(PeriodoLectivoRequestDto requestDTO) {
-        PeriodoLectivo periodoLectivo = new PeriodoLectivo();
-
-        periodoLectivo.setNombre(requestDTO.getNombre());
-        periodoLectivo.setFechaInicio(requestDTO.getFechaInicio());
-        periodoLectivo.setFechaFin(requestDTO.getFechaFin());
-
-        return periodoLectivo;
     }
 
 	@Override


### PR DESCRIPTION
- `PeriodoLectivo` ahora extiende a `BaseEntity`, junto a eso se elimino el campo id del primero y todas sus menciones.
- Se crearon `PeriodoLectivoResponseDto` y `PeriodoLectivoMapper ` junto a sus respectivos paquetes, ademas de crear un paquete para `PeriodoLectivoRequestDto`.
- Se modifico `IPeriodoLectivoService` y `PeriodoLectivoServiceImpl` para mover el metodo `fromDto` a  `PeriodoLectivoMapper `.
- Se modifico `PeriodoLectivoController` para utilizar las clases antes mencionadas. 