### PR TITLE
TP07 - Métodos mágicos en Asignación Docente

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/controller/AsignacionDocenteController.java
+++ b/src/main/java/com/imb2025/calificaciones/controller/AsignacionDocenteController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.imb2025.calificaciones.dto.AsignacionDocenteRequestDto;
@@ -22,6 +23,7 @@ import com.imb2025.calificaciones.service.IAsignacionDocenteService;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.HashMap;
 import java.util.List;
 
 @RestController
@@ -49,6 +51,25 @@ public class AsignacionDocenteController {
         resp.setData(asignacionDocente);
         resp.setMessage("Asignación docente obtenida exitosamente");
         return ResponseEntity.ok(resp);
+    }
+
+    @GetMapping("/get")
+    public ResponseEntity<ApiResponseSuccessDto<List<AsignacionDocente>>> getByDocenteId(
+            @RequestParam(required = true) Long docenteId) {
+        List<AsignacionDocente> asignaciones = service.findAllByDocenteId(docenteId);
+        ApiResponseSuccessDto<List<AsignacionDocente>> response = new ApiResponseSuccessDto<List<AsignacionDocente>>(true, "Asignaciones Docentes con el docenteId " + docenteId + " encontradas con éxito", asignaciones);
+        return asignaciones.isEmpty() ? ResponseEntity.noContent().build() : ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/count")
+    public ResponseEntity<ApiResponseSuccessDto<HashMap<String, Long>>> countByMateriaIdAndComisionId(
+            @RequestParam Long materiaId,
+            @RequestParam Long comisionId) {
+        Long count = service.countByMateriaIdAndComisionId(materiaId, comisionId);
+        HashMap<String, Long> hash = new HashMap<String, Long>();
+        hash.put("cantidad", count);
+        ApiResponseSuccessDto<HashMap<String, Long>> response = new ApiResponseSuccessDto<HashMap<String, Long>>(true, "", hash);
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping

--- a/src/main/java/com/imb2025/calificaciones/repository/AsignacionDocenteRepository.java
+++ b/src/main/java/com/imb2025/calificaciones/repository/AsignacionDocenteRepository.java
@@ -1,5 +1,6 @@
 package com.imb2025.calificaciones.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,5 +8,7 @@ import com.imb2025.calificaciones.entity.AsignacionDocente;
 
 @Repository
 public interface AsignacionDocenteRepository extends JpaRepository<AsignacionDocente, Long> {
+    List<AsignacionDocente> findByDocenteId(Long docenteId);
+    long countByMateriaIdAndComisionId(Long materiaId, Long comisionId);
 }
 

--- a/src/main/java/com/imb2025/calificaciones/service/IAsignacionDocenteService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/IAsignacionDocenteService.java
@@ -8,6 +8,10 @@ public interface IAsignacionDocenteService {
 
     public List<AsignacionDocente> findAll();
 
+    public List<AsignacionDocente> findAllByDocenteId(Long docenteId);
+
+    public long countByMateriaIdAndComisionId(Long materiaId, Long comisionId);
+
     public AsignacionDocente create(AsignacionDocente asignacionDocente);
 
     public AsignacionDocente update(AsignacionDocente asignacionDocente, Long id) throws Exception;

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/AsignacionDocenteServiceImpl.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/AsignacionDocenteServiceImpl.java
@@ -41,6 +41,16 @@ public class AsignacionDocenteServiceImpl implements IAsignacionDocenteService {
     }
 
     @Override
+    public List<AsignacionDocente> findAllByDocenteId(Long docenteId) {
+        return repository.findByDocenteId(docenteId);
+    }
+
+    @Override
+    public long countByMateriaIdAndComisionId(Long materiaId, Long comisionId) {
+        return repository.countByMateriaIdAndComisionId(materiaId, comisionId);
+    }
+
+    @Override
     public AsignacionDocente findById(Long id) {
         return repository.findById(id)
             .orElseThrow(() -> new ResourceNotFoundException(


### PR DESCRIPTION
# AsignacionDocente: Implementación de métodos findBy y countBy
Se implementaron dos nuevos métodos de consulta para AsignacionDocente siguiendo la estructura de PeriodoLectivo.

## Cambios realizados

### Repository
- Agregado método `findByDocenteId(Long docenteId)`
- Agregado método `countByMateriaIdAndComisionId(Long materiaId, Long comisionId)`

### Service
- Se implementan los métodos `findAllByDocenteId` y`countByMateriaIdAndComisionId`

### Controller
- Nuevo endpoint `GET /api/v1/asignacion-docente/get?docenteId={id}` para buscar por docente
- Nuevo endpoint `GET /api/v1/asignacion-docente/count?materiaId={id}&comisionId={id}` para contar asignaciones