### PR TITLE
Ejercicio 3: Fecha de vigencia y dos listados.

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/controller/ProductoController.java
+++ b/src/main/java/com/imb2025/calificaciones/controller/ProductoController.java
@@ -1,0 +1,65 @@
+package com.imb2025.calificaciones.controller;
+
+import com.imb2025.calificaciones.dto.request.ProductoRequestDto;
+import com.imb2025.calificaciones.dto.response.ProductoResponseDto;
+import com.imb2025.calificaciones.service.jpa.ProductoService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/productos")
+public class ProductoController {
+
+    private final ProductoService productoService;
+
+
+    public ProductoController(ProductoService productoService) {
+        this.productoService = productoService;
+    }
+
+  
+    @PostMapping
+    public ResponseEntity<?> create(@Valid @RequestBody ProductoRequestDto requestDto, BindingResult bindingResult) {
+        
+        
+        if (bindingResult.hasErrors()) {
+            List<String> errors = bindingResult.getAllErrors().stream()
+                    .map(error -> error.getDefaultMessage())
+                    .collect(Collectors.toList());
+            
+            Map<String, List<String>> responseBody = new HashMap<>();
+            responseBody.put("errors", errors);
+            return new ResponseEntity<>(responseBody, HttpStatus.BAD_REQUEST);
+        }
+
+
+        try {
+            ProductoResponseDto response = productoService.create(requestDto);
+            return new ResponseEntity<>(response, HttpStatus.CREATED);
+        } catch (Exception e) {
+            return new ResponseEntity<>(Map.of("error", "Error interno al crear el producto"), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+   
+    @GetMapping("/vigentes")
+    public ResponseEntity<List<ProductoResponseDto>> getVigentes() {
+        List<ProductoResponseDto> productosVigentes = productoService.findVigentes();
+        return new ResponseEntity<>(productosVigentes, HttpStatus.OK);
+    }
+
+    
+    @GetMapping("/vencidos")
+    public ResponseEntity<List<ProductoResponseDto>> getVencidos() {
+        List<ProductoResponseDto> productosVencidos = productoService.findVencidos();
+        return new ResponseEntity<>(productosVencidos, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/imb2025/calificaciones/dto/mapper/ProductoMapper.java
+++ b/src/main/java/com/imb2025/calificaciones/dto/mapper/ProductoMapper.java
@@ -1,0 +1,57 @@
+package com.imb2025.calificaciones.dto.mapper;
+
+import com.imb2025.calificaciones.dto.request.ProductoRequestDto;
+import com.imb2025.calificaciones.dto.response.ProductoResponseDto;
+import com.imb2025.calificaciones.entity.Producto;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class ProductoMapper {
+
+    
+    public Producto fromDto(ProductoRequestDto dto) {
+        if (dto == null) {
+            return null;
+        }
+
+        Producto producto = new Producto();
+        producto.setNombre(dto.getNombre());
+        producto.setPrecio(dto.getPrecio());
+        producto.setStock(dto.getStock());
+        
+
+        if (dto.getFechaVigencia() != null && dto.getFechaVigencia().matches("^\\d{4}-\\d{2}-\\d{2}$")) {
+            producto.setFechaVigencia(LocalDate.parse(dto.getFechaVigencia()));
+        }
+
+        return producto;
+    }
+
+    
+    public ProductoResponseDto toResponseDto(Producto producto) {
+        if (producto == null) {
+            return null;
+        }
+
+        ProductoResponseDto dto = new ProductoResponseDto();
+        dto.setId(producto.getId());
+        dto.setNombre(producto.getNombre());
+        dto.setPrecio(producto.getPrecio());
+        dto.setStock(producto.getStock());
+        dto.setFechaVigencia(producto.getFechaVigencia());
+        dto.setVersion(producto.getVersion());
+        
+        return dto;
+    }
+
+   
+    public List<ProductoResponseDto> toResponseDtoList(List<Producto> productos) {
+        return productos.stream()
+                .map(this::toResponseDto)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/imb2025/calificaciones/dto/request/ProductoRequestDto.java
+++ b/src/main/java/com/imb2025/calificaciones/dto/request/ProductoRequestDto.java
@@ -1,0 +1,37 @@
+package com.imb2025.calificaciones.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public class ProductoRequestDto {
+
+    @NotBlank(message = "El nombre no puede estar vacío.")
+    private String nombre;
+
+    @NotNull(message = "El precio no puede ser nulo.")
+    private Double precio;
+
+    @NotNull(message = "El stock no puede ser nulo.")
+    private Integer stock;
+
+    
+    @NotNull(message = "La fecha de vigencia no puede ser nula.")
+    @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "El formato de la fecha de vigencia debe ser AAAA-MM-DD.")
+    private String fechaVigencia;
+
+
+    public ProductoRequestDto() {}
+
+    
+    public String getNombre() { return nombre; }
+    public Double getPrecio() { return precio; }
+    public Integer getStock() { return stock; }
+    public String getFechaVigencia() { return fechaVigencia; }
+
+  
+    public void setNombre(String nombre) { this.nombre = nombre; }
+    public void setPrecio(Double precio) { this.precio = precio; }
+    public void setStock(Integer stock) { this.stock = stock; }
+    public void setFechaVigencia(String fechaVigencia) { this.fechaVigencia = fechaVigencia; }
+}

--- a/src/main/java/com/imb2025/calificaciones/dto/response/ProductoResponseDto.java
+++ b/src/main/java/com/imb2025/calificaciones/dto/response/ProductoResponseDto.java
@@ -1,0 +1,32 @@
+package com.imb2025.calificaciones.dto.response;
+
+import java.time.LocalDate;
+
+public class ProductoResponseDto {
+    private Long id;
+    private String nombre;
+    private Double precio;
+    private Integer stock;
+    
+    private LocalDate fechaVigencia;
+    private Integer version;
+
+   
+    public ProductoResponseDto() {}
+
+   
+    public Long getId() { return id; }
+    public String getNombre() { return nombre; }
+    public Double getPrecio() { return precio; }
+    public Integer getStock() { return stock; }
+    public LocalDate getFechaVigencia() { return fechaVigencia; }
+    public Integer getVersion() { return version; }
+
+    
+    public void setId(Long id) { this.id = id; }
+    public void setNombre(String nombre) { this.nombre = nombre; }
+    public void setPrecio(Double precio) { this.precio = precio; }
+    public void setStock(Integer stock) { this.stock = stock; }
+    public void setFechaVigencia(LocalDate fechaVigencia) { this.fechaVigencia = fechaVigencia; }
+    public void setVersion(Integer version) { this.version = version; }
+}

--- a/src/main/java/com/imb2025/calificaciones/entity/Producto.java
+++ b/src/main/java/com/imb2025/calificaciones/entity/Producto.java
@@ -1,0 +1,93 @@
+package com.imb2025.calificaciones.entity;
+
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Version;
+
+import java.time.LocalDate;
+
+@Entity
+public class Producto {
+
+ @Id
+ @GeneratedValue(strategy = GenerationType.IDENTITY)
+ private Long id;
+
+ private String nombre;
+ private Double precio;
+ private Integer stock;
+
+
+ @Column(nullable = false)
+ private LocalDate fechaVigencia;
+
+ @Version
+ private Integer version;
+
+ 
+ public Producto() {}
+
+ public Producto(Long id, String nombre, Double precio, Integer stock, LocalDate fechaVigencia, Integer version) {
+     this.id = id;
+     this.nombre = nombre;
+     this.precio = precio;
+     this.stock = stock;
+     this.fechaVigencia = fechaVigencia;
+     this.version = version;
+ }
+
+
+ public Long getId() {
+     return id;
+ }
+
+ public String getNombre() {
+     return nombre;
+ }
+
+ public Double getPrecio() {
+     return precio;
+ }
+
+ public Integer getStock() {
+     return stock;
+ }
+
+ public LocalDate getFechaVigencia() {
+     return fechaVigencia;
+ }
+
+ public Integer getVersion() {
+     return version;
+ }
+
+
+ public void setId(Long id) {
+     this.id = id;
+ }
+
+ public void setNombre(String nombre) {
+     this.nombre = nombre;
+ }
+
+ public void setPrecio(Double precio) {
+     this.precio = precio;
+ }
+
+ public void setStock(Integer stock) {
+     this.stock = stock;
+ }
+
+ public void setFechaVigencia(LocalDate fechaVigencia) {
+     this.fechaVigencia = fechaVigencia;
+ }
+
+ public void setVersion(Integer version) {
+     this.version = version;
+ }
+}

--- a/src/main/java/com/imb2025/calificaciones/repository/ProductoRepository.java
+++ b/src/main/java/com/imb2025/calificaciones/repository/ProductoRepository.java
@@ -1,0 +1,16 @@
+package com.imb2025.calificaciones.repository;
+
+import com.imb2025.calificaciones.entity.Producto;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public interface ProductoRepository extends JpaRepository<Producto, Long> {
+
+    List<Producto> findByFechaVigenciaGreaterThanEqual(LocalDate fecha);
+
+    List<Producto> findByFechaVigenciaLessThan(LocalDate fecha);
+}

--- a/src/main/java/com/imb2025/calificaciones/service/jpa/ProductoService.java
+++ b/src/main/java/com/imb2025/calificaciones/service/jpa/ProductoService.java
@@ -1,0 +1,47 @@
+package com.imb2025.calificaciones.service.jpa;
+
+import com.imb2025.calificaciones.dto.request.ProductoRequestDto;
+import com.imb2025.calificaciones.dto.response.ProductoResponseDto;
+import com.imb2025.calificaciones.entity.Producto;
+import com.imb2025.calificaciones.dto.mapper.ProductoMapper;
+import com.imb2025.calificaciones.repository.ProductoRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+public class ProductoService {
+
+    private final ProductoRepository productoRepository;
+    private final ProductoMapper productoMapper;
+
+
+    public ProductoService(ProductoRepository productoRepository, ProductoMapper productoMapper) {
+        this.productoRepository = productoRepository;
+        this.productoMapper = productoMapper;
+    }
+
+    @Transactional
+    public ProductoResponseDto create(ProductoRequestDto requestDto) {
+        Producto producto = productoMapper.fromDto(requestDto);
+        Producto savedProducto = productoRepository.save(producto);
+        return productoMapper.toResponseDto(savedProducto);
+    }
+    
+   
+    @Transactional(readOnly = true)
+    public List<ProductoResponseDto> findVigentes() {
+        LocalDate hoy = LocalDate.now();
+        List<Producto> vigentes = productoRepository.findByFechaVigenciaGreaterThanEqual(hoy);
+        return productoMapper.toResponseDtoList(vigentes);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProductoResponseDto> findVencidos() {
+        LocalDate hoy = LocalDate.now();
+        List<Producto> vencidos = productoRepository.findByFechaVigenciaLessThan(hoy);
+        return productoMapper.toResponseDtoList(vencidos);
+    }
+}


### PR DESCRIPTION
Ejercicio elegido: Ejercicio 3: Fecha de vigencia y dos listados.

Entidad adaptada: Producto.

Resumen: Se ha implementado el atributo fechaVigencia en la entidad Producto. La solución incluye validaciones de no nulo y formato AAAA-MM-DD en el DTO de solicitud. Se agregaron dos endpoints sin parametrización que listan productos:

/api/productos/vigentes (fechaVigencia >= hoy)

/api/productos/vencidos (fechaVigencia < hoy)